### PR TITLE
Rewrite Test 1

### DIFF
--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -1,0 +1,23 @@
+@wip
+Feature: Fetching Resources with LDS and CDS
+  Client can do wildcard subscriptions or normal subscriptions
+  and receive updates when any subscribed resources change.
+
+  These features come from this list of test cases:
+  https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
+
+  Scenario Outline: The service should send all resources on a wildcard request.
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client does a wildcard subscription to <service>
+    Then the Client receives the <expected resources> and <starting version> for <service>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      # Steps 3 and 5 should fail
+      | service | starting version | resources | expected resources |
+      | "CDS"   | "1"              | "A,B,C"   | "A,B,C"            |
+      | "CDS"   | "1"              | "A,B,C"   | "C,A,B"            |
+      | "CDS"   | "1"              | "A,B,C"   | "B,A,D"            |
+      | "LDS"   | "1"              | "D,E,F"   | "D,E,F"            |
+      | "LDS"   | "1"              | "D,E,F"   | "F,A,I,L"          |
+      | "LDS"   | "1"              | "D,E,F"   | "F,D,E"            |

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -61,3 +61,10 @@ type DiscoveryResponse struct {
 	Resources   []Cluster `yaml:"resources"` //hack for now, should be any type of resource
 	Nonce       string    `default:"" yaml:"nonce"`
 }
+
+type SimpleResponse struct {
+	// Only the info used for validating our tests
+	Version string
+	Resources []string
+	Nonce string
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -128,16 +128,16 @@ func (r *Runner) NewCDSRequest(resourceList []string) *discovery.DiscoveryReques
 }
 
 func (r *Runner) NewRequest(resourceList []string, typeURL string) *discovery.DiscoveryRequest {
-	clusters := []string{}
-	for _, cluster := range resourceList {
-		clusters = append(clusters, cluster)
+	resourceNames := []string{}
+	for _, name := range resourceList {
+		resourceNames = append(resourceNames, name)
 	}
 	return &discovery.DiscoveryRequest{
 		VersionInfo: "",
 		Node: &core.Node{
 			Id: r.NodeID,
 		},
-		ResourceNames: clusters,
+		ResourceNames: resourceNames,
 		TypeUrl:       typeURL,
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -11,6 +11,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	cds "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
+	lds "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"github.com/ii/xds-test-harness/internal/parser"
@@ -37,7 +38,7 @@ type Cache struct {
 	FinalResponse *discovery.DiscoveryResponse
 }
 
-type CDS struct {
+type Service struct {
 	Req   chan *discovery.DiscoveryRequest
 	Res   chan *discovery.DiscoveryResponse
 	Err   chan error
@@ -54,7 +55,8 @@ type Runner struct {
 	Target  *ClientConfig
 	NodeID  string
 	Cache   *Cache
-	CDS     *CDS
+	CDS     *Service
+	LDS     *Service
 }
 
 func NewRunner() *Runner {
@@ -63,7 +65,8 @@ func NewRunner() *Runner {
 		Target:  &ClientConfig{},
 		NodeID:  "",
 		Cache:   &Cache{},
-		CDS:     &CDS{},
+		CDS:     &Service{},
+		LDS:     &Service{},
 	}
 }
 
@@ -73,7 +76,8 @@ func FreshRunner (current *Runner) *Runner {
 		Target: current.Target,
 		NodeID: current.NodeID,
 		Cache: &Cache{},
-		CDS: &CDS{},
+		CDS: &Service{},
+		LDS: &Service{},
 	}
 }
 
@@ -123,7 +127,22 @@ func (r *Runner) NewCDSRequest(resourceList []string) *discovery.DiscoveryReques
 	}
 }
 
-func (r *Runner) NewCDSAckFromResponse(res *discovery.DiscoveryResponse) (*discovery.DiscoveryRequest, error) {
+func (r *Runner) NewRequest(resourceList []string, typeURL string) *discovery.DiscoveryRequest {
+	clusters := []string{}
+	for _, cluster := range resourceList {
+		clusters = append(clusters, cluster)
+	}
+	return &discovery.DiscoveryRequest{
+		VersionInfo: "",
+		Node: &core.Node{
+			Id: r.NodeID,
+		},
+		ResourceNames: clusters,
+		TypeUrl:       typeURL,
+	}
+}
+
+func (r *Runner) NewCDSAckFromResponse(res *discovery.DiscoveryResponse, typeURL string) (*discovery.DiscoveryRequest, error) {
 	response, err := parser.ParseDiscoveryResponse(res)
 	if err != nil {
 		err := fmt.Errorf("error parsing dres for acking: %v", err)
@@ -133,13 +152,13 @@ func (r *Runner) NewCDSAckFromResponse(res *discovery.DiscoveryResponse) (*disco
 	request := &discovery.DiscoveryRequest{
 		VersionInfo:   response.VersionInfo,
 		ResourceNames: r.CDS.Cache.InitResource,
-		TypeUrl:       "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+		TypeUrl:       typeURL,
 		ResponseNonce: response.Nonce,
 	}
 	return request, nil
 }
 
-func (r *Runner) AckCDS(initReq *discovery.DiscoveryRequest) {
+func (r *Runner) AckCDS(initReq *discovery.DiscoveryRequest, typeURL string) {
 
 	log.Debug().Msgf("Sending First Discovery Request", initReq)
 	r.CDS.Req <- initReq
@@ -149,7 +168,7 @@ func (r *Runner) AckCDS(initReq *discovery.DiscoveryRequest) {
 		select {
 		case res := <-r.CDS.Res:
 			r.CDS.Cache.Responses = append(r.CDS.Cache.Responses, res)
-			ack, err := r.NewCDSAckFromResponse(res)
+			ack, err := r.NewCDSAckFromResponse(res, initReq.TypeUrl)
 			if err != nil {
 				log.Err(err).Msg("Error creating Ack Request")
 			}
@@ -163,6 +182,95 @@ func (r *Runner) AckCDS(initReq *discovery.DiscoveryRequest) {
 			return
 		}
 	}
+}
+
+func (r *Runner) NewAckFromResponse(res *discovery.DiscoveryResponse, initReq *discovery.DiscoveryRequest) (*discovery.DiscoveryRequest, error) {
+	response, err := parser.ParseDiscoveryResponseV2(res)
+	if err != nil {
+		err := fmt.Errorf("error parsing dres for acking: %v", err)
+		return nil, err
+	}
+
+	request := &discovery.DiscoveryRequest{
+		VersionInfo:   response.Version,
+		ResourceNames: initReq.ResourceNames,
+		TypeUrl:       initReq.TypeUrl,
+		ResponseNonce: response.Nonce,
+	}
+
+	return request, nil
+}
+
+func (r *Runner) Ack (initReq *discovery.DiscoveryRequest, service *Service) {
+	service.Req <- initReq
+	service.Cache.Requests = append(service.Cache.Requests, initReq)
+	for {
+		select {
+		case res := <- service.Res:
+			service.Cache.Responses = append(service.Cache.Responses, res)
+			ack, err := r.NewAckFromResponse(res, initReq)
+			if err != nil {
+				service.Err <- err
+				return
+			}
+			log.Debug().
+				Msgf("Sending Ack: %v", ack)
+			service.Req <- ack
+	        service.Cache.Requests = append(service.Cache.Requests, ack)
+		case <- service.Done:
+			log.Debug().Msg("Received Done signal, shutting down request channel")
+			close(service.Req)
+			return
+		}
+	}
+}
+
+func (r *Runner) LDSStream() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	defer close(r.LDS.Err)
+
+	client := lds.NewListenerDiscoveryServiceClient(r.Target.Conn)
+	stream, err := client.StreamListeners(ctx)
+	if err != nil {
+		err = errors.New(fmt.Sprintf("Cannot start LDS stream %v. error: %v", stream, err))
+		log.Debug().
+			Err(err).
+			Msg("")
+		r.LDS.Err <- err
+	}
+	var wg sync.WaitGroup
+	go func() {
+		for {
+			wg.Add(1)
+			in, err := stream.Recv()
+			if err == io.EOF {
+				log.Debug().
+					Msg("No more Discovery Responses from LDS stream")
+				close(r.LDS.Res)
+				return
+			}
+			if err != nil {
+				log.Err(err).Msg("error receiving responses on LDS stream")
+				r.LDS.Err <- err
+				return
+			}
+			log.Debug().
+				Msgf("Received discovery response: %v", in)
+			r.LDS.Res <- in
+		}
+	}()
+
+	for req := range r.LDS.Req {
+		if err := stream.Send(req); err != nil {
+			log.Err(err).
+				Msg("Error sending discovery request")
+			r.LDS.Err <- err
+		}
+	}
+	stream.CloseSend()
+	wg.Wait()
+	return err
 }
 
 func (r *Runner) CDSStream() error {

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -3,7 +3,9 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -102,11 +104,27 @@ func (r *Runner) ClientSubscribesToWildcardCDS() error {
 	r.CDS.Done = make(chan bool, 1)
 	r.CDS.Cache.InitResource = []string{}
 
-	request := r.NewCDSRequest(r.CDS.Cache.InitResource)
+	typeURL := "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+	request := r.NewRequest(r.CDS.Cache.InitResource, typeURL)
 
 	go r.CDSStream()
-	go r.AckCDS(request)
+	go r.Ack(request, r.CDS)
 	return nil
+}
+
+func (r *Runner) ClientSubscribesToWildcardLDS() {
+	r.LDS.Req = make(chan *discovery.DiscoveryRequest, 1)
+	r.LDS.Res = make(chan *discovery.DiscoveryResponse, 1)
+	r.LDS.Err = make(chan error, 1)
+	r.LDS.Done = make(chan bool, 1)
+	r.LDS.Cache.InitResource = []string{}
+
+	typeURL := "type.googleapis.com/envoy.config.listener.v3.Listener"
+
+	request := r.NewRequest(r.LDS.Cache.InitResource, typeURL)
+
+	go r.LDSStream()
+	go r.Ack(request, r.LDS)
 }
 
 func (r *Runner) TheClientSubscribesToTheFollowingResources(resources *godog.DocString) error {
@@ -123,11 +141,9 @@ func (r *Runner) TheClientSubscribesToTheFollowingResources(resources *godog.Doc
 	request := r.NewCDSRequest(r.CDS.Cache.InitResource)
 
 	go r.CDSStream()
-	go r.AckCDS(request)
+	go r.Ack(request, r.CDS)
 	return nil
 }
-
-
 
 func (r *Runner) ClientReceivesTheFollowingVersionAndClustersAlongWithNonce(resources *godog.DocString) error {
 	expected, err := parser.YamlToSnapshot(r.NodeID, resources.Content)
@@ -184,6 +200,105 @@ func (r *Runner) TheClientSendsAnACKToWhichTheServerDoesNotRespond() error {
 	return nil
 }
 
+
+func (r *Runner) ATargetSetupWithServiceResourcesAndVersion(service, resources, version string) error {
+	snapshot := &pb.Snapshot{
+		Node:      r.NodeID,
+		Version:   fmt.Sprint(version),
+		Clusters: &pb.Clusters{},
+	}
+
+	if service == "LDS" {
+		listeners := parser.ToListeners(resources)
+		snapshot.Listeners = listeners
+	}
+	if service == "CDS" {
+		clusters := parser.ToClusters(resources)
+		snapshot.Clusters = clusters
+	}
+
+	c := pb.NewAdapterClient(r.Adapter.Conn)
+
+	_, err := c.SetState(context.Background(), snapshot)
+	if err != nil {
+		msg := "Cannot set target with given state"
+		log.Error().
+			Err(err).
+			Msg(msg)
+		return errors.New(msg)
+	}
+
+	r.Cache.StartState = snapshot
+	return nil
+}
+
+func (r *Runner) TheClientDoesAWildcardSubscriptionToService(service string) error {
+	if service == "CDS" {
+		r.ClientSubscribesToWildcardCDS()
+	}
+	if service == "LDS" {
+		r.ClientSubscribesToWildcardLDS()
+	}
+	return nil
+}
+
+func (r *Runner) TheClientReceivesCorrectResourcesAndVersionForService(resources, version, service string) error {
+	var stream *Service
+	expectedResources := strings.Split(resources, ",")
+
+	if service == "CDS" {
+		stream = r.CDS
+	}
+	if service == "LDS" {
+		stream = r.LDS
+	}
+
+	for {
+		select {
+		case err := <- stream.Err:
+			log.Err(err).Msg("From our step")
+			return errors.New("Could not find expected response within grace period of 10 seconds.")
+		default:
+			if len(stream.Cache.Responses) > 0 {
+				for _, response := range stream.Cache.Responses {
+				    actual, err := parser.ParseDiscoveryResponseV2(response)
+					if err != nil {
+						log.Error().Err(err).Msg("can't parse discovery response ")
+						return err
+					}
+					if actual.Version == version && sortCompare(expectedResources, actual.Resources) {
+						return nil
+					}
+				}
+			}
+		}
+	}
+}
+
+func (r *Runner) TheClientSendsAnACKToWhichTheDoesNotRespond(service string) error {
+	var stream *Service
+	if service == "CDS" {
+		stream = r.CDS
+	}
+	if service == "LDS" {
+		stream = r.LDS
+	}
+	stream.Done <- true
+
+	// give some time for the final messages to come through, if there's any lingering responses.
+	time.Sleep(3 * time.Second)
+	log.Debug().
+		Msgf("Request Count: %v Response Count: %v", len(stream.Cache.Requests), len(stream.Cache.Responses))
+	if len(stream.Cache.Requests) <= len(stream.Cache.Responses) {
+		err := errors.New("There are more responses than requests.  This indicates the server responded to the last ack")
+		log.Err(err).
+			Msgf("Requests:%v, Responses: \v", stream.Cache.Requests, stream.Cache.Responses)
+		return err
+	}
+	return nil
+}
+
+
 func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^a target setup with the following state:$`, r.ATargetSetupWithTheFollowingState)
 	ctx.Step(`^the Client subscribes to wildcard CDS$`, r.ClientSubscribesToWildcardCDS)
@@ -191,4 +306,8 @@ func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the Client receives the following version and clusters, along with a nonce:$`, r.ClientReceivesTheFollowingVersionAndClustersAlongWithNonce)
 	ctx.Step(`^the Client sends an ACK to which the server does not respond$`, r.TheClientSendsAnACKToWhichTheServerDoesNotRespond)
     ctx.Step(`^the Target is updated to the following state:$`, r.TheTargetIsUpdatedToTheFollowingState)
+    ctx.Step(`^a target setup with "([^"]*)", "([^"]*)", and "([^"]*)"$`, r.ATargetSetupWithServiceResourcesAndVersion)
+	ctx.Step(`^the Client does a wildcard subscription to "([^"]*)"$`, r.TheClientDoesAWildcardSubscriptionToService)
+    ctx.Step(`^the Client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersionForService)
+	ctx.Step(`^the Client sends an ACK to which the "([^"]*)" does not respond$`, r.TheClientSendsAnACKToWhichTheDoesNotRespond)
 }


### PR DESCRIPTION
Setup a test case in a style that allows us to succinctly test LDS and
CDS on the same behaviour.  This required refactoring our runner
functions to work for any service, and to write new step functions to
take advantage of the new way we are passing in parameters.

The new test is designed to fail on 2 of the 6 cases, to assure that a
test can fail but the test suite itself can continue to run.

# Running the Test
**1. Setup Test Target**
In one terminal window, from the root of this repo, invoke:
```sh
go run example/go-control-plane/main/main.go
```
You should see:
```
{timestamp} management server listening on 18000
{timestamp} Testsuite Adapter listening on 17000
```
**2. Run Test Suite**
In a new terminal window, from the root of this repo, invoke:
```sh
go run . -t "@wip"
```
This will run our test 6 times, and it should fail twice.  

Optionally you can run:
```
go run . -t "@wip" --debug # verbose logging through test
go run . # run the whole suite
```

**Note**:  
When you look at the code in entirety, you'll see there are some overly similar functions.  This is to ensure that all the previous steps can still run, and to keep this PR as small as possible.  When this work gets merged, I will refactor and delete those now deprecated steps.