### PR TITLE
Test 2

### DIFF
--- a/api/adapter/adapter.pb.go
+++ b/api/adapter/adapter.pb.go
@@ -452,6 +452,53 @@ func (x *SetStateResponse) GetMessage() string {
 	return ""
 }
 
+type UpdateStateResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+}
+
+func (x *UpdateStateResponse) Reset() {
+	*x = UpdateStateResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_api_adapter_adapter_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *UpdateStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateStateResponse) ProtoMessage() {}
+
+func (x *UpdateStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_adapter_adapter_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateStateResponse.ProtoReflect.Descriptor instead.
+func (*UpdateStateResponse) Descriptor() ([]byte, []int) {
+	return file_api_adapter_adapter_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *UpdateStateResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 type ClearRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -463,7 +510,7 @@ type ClearRequest struct {
 func (x *ClearRequest) Reset() {
 	*x = ClearRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[8]
+		mi := &file_api_adapter_adapter_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -476,7 +523,7 @@ func (x *ClearRequest) String() string {
 func (*ClearRequest) ProtoMessage() {}
 
 func (x *ClearRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[8]
+	mi := &file_api_adapter_adapter_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -489,7 +536,7 @@ func (x *ClearRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearRequest.ProtoReflect.Descriptor instead.
 func (*ClearRequest) Descriptor() ([]byte, []int) {
-	return file_api_adapter_adapter_proto_rawDescGZIP(), []int{8}
+	return file_api_adapter_adapter_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ClearRequest) GetNode() string {
@@ -510,7 +557,7 @@ type ClearResponse struct {
 func (x *ClearResponse) Reset() {
 	*x = ClearResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[9]
+		mi := &file_api_adapter_adapter_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -523,7 +570,7 @@ func (x *ClearResponse) String() string {
 func (*ClearResponse) ProtoMessage() {}
 
 func (x *ClearResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[9]
+	mi := &file_api_adapter_adapter_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -536,7 +583,7 @@ func (x *ClearResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearResponse.ProtoReflect.Descriptor instead.
 func (*ClearResponse) Descriptor() ([]byte, []int) {
-	return file_api_adapter_adapter_proto_rawDescGZIP(), []int{9}
+	return file_api_adapter_adapter_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ClearResponse) GetResponse() string {
@@ -557,7 +604,7 @@ type Endpoints_Endpoint struct {
 func (x *Endpoints_Endpoint) Reset() {
 	*x = Endpoints_Endpoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[10]
+		mi := &file_api_adapter_adapter_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -570,7 +617,7 @@ func (x *Endpoints_Endpoint) String() string {
 func (*Endpoints_Endpoint) ProtoMessage() {}
 
 func (x *Endpoints_Endpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[10]
+	mi := &file_api_adapter_adapter_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -605,7 +652,7 @@ type Clusters_Cluster struct {
 func (x *Clusters_Cluster) Reset() {
 	*x = Clusters_Cluster{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[11]
+		mi := &file_api_adapter_adapter_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -618,7 +665,7 @@ func (x *Clusters_Cluster) String() string {
 func (*Clusters_Cluster) ProtoMessage() {}
 
 func (x *Clusters_Cluster) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[11]
+	mi := &file_api_adapter_adapter_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -659,7 +706,7 @@ type Routes_Route struct {
 func (x *Routes_Route) Reset() {
 	*x = Routes_Route{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[13]
+		mi := &file_api_adapter_adapter_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -672,7 +719,7 @@ func (x *Routes_Route) String() string {
 func (*Routes_Route) ProtoMessage() {}
 
 func (x *Routes_Route) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[13]
+	mi := &file_api_adapter_adapter_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -707,7 +754,7 @@ type Listeners_Listener struct {
 func (x *Listeners_Listener) Reset() {
 	*x = Listeners_Listener{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[14]
+		mi := &file_api_adapter_adapter_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -720,7 +767,7 @@ func (x *Listeners_Listener) String() string {
 func (*Listeners_Listener) ProtoMessage() {}
 
 func (x *Listeners_Listener) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[14]
+	mi := &file_api_adapter_adapter_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -761,7 +808,7 @@ type Runtimes_Runtime struct {
 func (x *Runtimes_Runtime) Reset() {
 	*x = Runtimes_Runtime{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[15]
+		mi := &file_api_adapter_adapter_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -774,7 +821,7 @@ func (x *Runtimes_Runtime) String() string {
 func (*Runtimes_Runtime) ProtoMessage() {}
 
 func (x *Runtimes_Runtime) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[15]
+	mi := &file_api_adapter_adapter_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -808,7 +855,7 @@ type Secrets_Secret struct {
 func (x *Secrets_Secret) Reset() {
 	*x = Secrets_Secret{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_api_adapter_adapter_proto_msgTypes[16]
+		mi := &file_api_adapter_adapter_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -821,7 +868,7 @@ func (x *Secrets_Secret) String() string {
 func (*Secrets_Secret) ProtoMessage() {}
 
 func (x *Secrets_Secret) ProtoReflect() protoreflect.Message {
-	mi := &file_api_adapter_adapter_proto_msgTypes[16]
+	mi := &file_api_adapter_adapter_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -919,24 +966,31 @@ var file_api_adapter_adapter_proto_rawDesc = []byte{
 	0x73, 0x22, 0x2c, 0x0a, 0x10, 0x53, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52, 0x65, 0x73,
 	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x22,
-	0x22, 0x0a, 0x0c, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
-	0x12, 0x0a, 0x04, 0x6e, 0x6f, 0x64, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e,
-	0x6f, 0x64, 0x65, 0x22, 0x2b, 0x0a, 0x0d, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x73, 0x70,
-	0x6f, 0x6e, 0x73, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
-	0x32, 0x84, 0x01, 0x0a, 0x07, 0x41, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x12, 0x3a, 0x0a, 0x08,
-	0x53, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x11, 0x2e, 0x61, 0x64, 0x61, 0x70, 0x74,
-	0x65, 0x72, 0x2e, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x1a, 0x19, 0x2e, 0x61, 0x64,
-	0x61, 0x70, 0x74, 0x65, 0x72, 0x2e, 0x53, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x3d, 0x0a, 0x0a, 0x43, 0x6c, 0x65, 0x61,
-	0x72, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x15, 0x2e, 0x61, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72,
-	0x2e, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x16, 0x2e,
-	0x61, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x2e, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x73,
-	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x3c, 0x5a, 0x3a, 0x67, 0x69, 0x74, 0x68, 0x75,
-	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x7a, 0x61, 0x63, 0x68, 0x6d, 0x61, 0x6e, 0x64, 0x65, 0x76,
-	0x69, 0x6c, 0x6c, 0x65, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x65, 0x72, 0x2d, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x74, 0x79, 0x70, 0x65, 0x2f, 0x61, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x2f, 0x61, 0x64,
-	0x61, 0x70, 0x74, 0x65, 0x72, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x2f, 0x0a, 0x13, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67,
+	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65,
+	0x22, 0x22, 0x0a, 0x0c, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x6f, 0x64, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+	0x6e, 0x6f, 0x64, 0x65, 0x22, 0x2b, 0x0a, 0x0d, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x1a, 0x0a, 0x08, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x32, 0xc6, 0x01, 0x0a, 0x07, 0x41, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x12, 0x3a, 0x0a,
+	0x08, 0x53, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x11, 0x2e, 0x61, 0x64, 0x61, 0x70,
+	0x74, 0x65, 0x72, 0x2e, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x1a, 0x19, 0x2e, 0x61,
+	0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x2e, 0x53, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x40, 0x0a, 0x0b, 0x55, 0x70, 0x64,
+	0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x11, 0x2e, 0x61, 0x64, 0x61, 0x70, 0x74,
+	0x65, 0x72, 0x2e, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x1a, 0x1c, 0x2e, 0x61, 0x64,
+	0x61, 0x70, 0x74, 0x65, 0x72, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x53, 0x74, 0x61, 0x74,
+	0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x3d, 0x0a, 0x0a, 0x43,
+	0x6c, 0x65, 0x61, 0x72, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x15, 0x2e, 0x61, 0x64, 0x61, 0x70,
+	0x74, 0x65, 0x72, 0x2e, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x1a, 0x16, 0x2e, 0x61, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x2e, 0x63, 0x6c, 0x65, 0x61, 0x72,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x3c, 0x5a, 0x3a, 0x67, 0x69,
+	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x7a, 0x61, 0x63, 0x68, 0x6d, 0x61, 0x6e,
+	0x64, 0x65, 0x76, 0x69, 0x6c, 0x6c, 0x65, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x65, 0x72, 0x2d, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x74, 0x79, 0x70, 0x65, 0x2f, 0x61, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72,
+	0x2f, 0x61, 0x64, 0x61, 0x70, 0x74, 0x65, 0x72, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -951,46 +1005,49 @@ func file_api_adapter_adapter_proto_rawDescGZIP() []byte {
 	return file_api_adapter_adapter_proto_rawDescData
 }
 
-var file_api_adapter_adapter_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_api_adapter_adapter_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_api_adapter_adapter_proto_goTypes = []interface{}{
-	(*Endpoints)(nil),          // 0: adapter.Endpoints
-	(*Clusters)(nil),           // 1: adapter.Clusters
-	(*Routes)(nil),             // 2: adapter.Routes
-	(*Listeners)(nil),          // 3: adapter.Listeners
-	(*Runtimes)(nil),           // 4: adapter.Runtimes
-	(*Secrets)(nil),            // 5: adapter.Secrets
-	(*Snapshot)(nil),           // 6: adapter.Snapshot
-	(*SetStateResponse)(nil),   // 7: adapter.SetStateResponse
-	(*ClearRequest)(nil),       // 8: adapter.clearRequest
-	(*ClearResponse)(nil),      // 9: adapter.clearResponse
-	(*Endpoints_Endpoint)(nil), // 10: adapter.Endpoints.Endpoint
-	(*Clusters_Cluster)(nil),   // 11: adapter.Clusters.Cluster
-	nil,                        // 12: adapter.Clusters.Cluster.ConnectTimeoutEntry
-	(*Routes_Route)(nil),       // 13: adapter.Routes.Route
-	(*Listeners_Listener)(nil), // 14: adapter.Listeners.Listener
-	(*Runtimes_Runtime)(nil),   // 15: adapter.Runtimes.Runtime
-	(*Secrets_Secret)(nil),     // 16: adapter.Secrets.Secret
+	(*Endpoints)(nil),           // 0: adapter.Endpoints
+	(*Clusters)(nil),            // 1: adapter.Clusters
+	(*Routes)(nil),              // 2: adapter.Routes
+	(*Listeners)(nil),           // 3: adapter.Listeners
+	(*Runtimes)(nil),            // 4: adapter.Runtimes
+	(*Secrets)(nil),             // 5: adapter.Secrets
+	(*Snapshot)(nil),            // 6: adapter.Snapshot
+	(*SetStateResponse)(nil),    // 7: adapter.SetStateResponse
+	(*UpdateStateResponse)(nil), // 8: adapter.UpdateStateResponse
+	(*ClearRequest)(nil),        // 9: adapter.clearRequest
+	(*ClearResponse)(nil),       // 10: adapter.clearResponse
+	(*Endpoints_Endpoint)(nil),  // 11: adapter.Endpoints.Endpoint
+	(*Clusters_Cluster)(nil),    // 12: adapter.Clusters.Cluster
+	nil,                         // 13: adapter.Clusters.Cluster.ConnectTimeoutEntry
+	(*Routes_Route)(nil),        // 14: adapter.Routes.Route
+	(*Listeners_Listener)(nil),  // 15: adapter.Listeners.Listener
+	(*Runtimes_Runtime)(nil),    // 16: adapter.Runtimes.Runtime
+	(*Secrets_Secret)(nil),      // 17: adapter.Secrets.Secret
 }
 var file_api_adapter_adapter_proto_depIdxs = []int32{
-	10, // 0: adapter.Endpoints.items:type_name -> adapter.Endpoints.Endpoint
-	11, // 1: adapter.Clusters.items:type_name -> adapter.Clusters.Cluster
-	13, // 2: adapter.Routes.items:type_name -> adapter.Routes.Route
-	14, // 3: adapter.Listeners.items:type_name -> adapter.Listeners.Listener
-	15, // 4: adapter.Runtimes.items:type_name -> adapter.Runtimes.Runtime
-	16, // 5: adapter.Secrets.items:type_name -> adapter.Secrets.Secret
+	11, // 0: adapter.Endpoints.items:type_name -> adapter.Endpoints.Endpoint
+	12, // 1: adapter.Clusters.items:type_name -> adapter.Clusters.Cluster
+	14, // 2: adapter.Routes.items:type_name -> adapter.Routes.Route
+	15, // 3: adapter.Listeners.items:type_name -> adapter.Listeners.Listener
+	16, // 4: adapter.Runtimes.items:type_name -> adapter.Runtimes.Runtime
+	17, // 5: adapter.Secrets.items:type_name -> adapter.Secrets.Secret
 	0,  // 6: adapter.Snapshot.endpoints:type_name -> adapter.Endpoints
 	1,  // 7: adapter.Snapshot.clusters:type_name -> adapter.Clusters
 	2,  // 8: adapter.Snapshot.routes:type_name -> adapter.Routes
 	3,  // 9: adapter.Snapshot.listeners:type_name -> adapter.Listeners
 	4,  // 10: adapter.Snapshot.runtimes:type_name -> adapter.Runtimes
 	5,  // 11: adapter.Snapshot.secrets:type_name -> adapter.Secrets
-	12, // 12: adapter.Clusters.Cluster.connect_timeout:type_name -> adapter.Clusters.Cluster.ConnectTimeoutEntry
+	13, // 12: adapter.Clusters.Cluster.connect_timeout:type_name -> adapter.Clusters.Cluster.ConnectTimeoutEntry
 	6,  // 13: adapter.Adapter.SetState:input_type -> adapter.Snapshot
-	8,  // 14: adapter.Adapter.ClearState:input_type -> adapter.clearRequest
-	7,  // 15: adapter.Adapter.SetState:output_type -> adapter.SetStateResponse
-	9,  // 16: adapter.Adapter.ClearState:output_type -> adapter.clearResponse
-	15, // [15:17] is the sub-list for method output_type
-	13, // [13:15] is the sub-list for method input_type
+	6,  // 14: adapter.Adapter.UpdateState:input_type -> adapter.Snapshot
+	9,  // 15: adapter.Adapter.ClearState:input_type -> adapter.clearRequest
+	7,  // 16: adapter.Adapter.SetState:output_type -> adapter.SetStateResponse
+	8,  // 17: adapter.Adapter.UpdateState:output_type -> adapter.UpdateStateResponse
+	10, // 18: adapter.Adapter.ClearState:output_type -> adapter.clearResponse
+	16, // [16:19] is the sub-list for method output_type
+	13, // [13:16] is the sub-list for method input_type
 	13, // [13:13] is the sub-list for extension type_name
 	13, // [13:13] is the sub-list for extension extendee
 	0,  // [0:13] is the sub-list for field type_name
@@ -1099,7 +1156,7 @@ func file_api_adapter_adapter_proto_init() {
 			}
 		}
 		file_api_adapter_adapter_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ClearRequest); i {
+			switch v := v.(*UpdateStateResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1111,7 +1168,7 @@ func file_api_adapter_adapter_proto_init() {
 			}
 		}
 		file_api_adapter_adapter_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ClearResponse); i {
+			switch v := v.(*ClearRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1123,7 +1180,7 @@ func file_api_adapter_adapter_proto_init() {
 			}
 		}
 		file_api_adapter_adapter_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Endpoints_Endpoint); i {
+			switch v := v.(*ClearResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1135,6 +1192,18 @@ func file_api_adapter_adapter_proto_init() {
 			}
 		}
 		file_api_adapter_adapter_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Endpoints_Endpoint); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_api_adapter_adapter_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Clusters_Cluster); i {
 			case 0:
 				return &v.state
@@ -1146,7 +1215,7 @@ func file_api_adapter_adapter_proto_init() {
 				return nil
 			}
 		}
-		file_api_adapter_adapter_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+		file_api_adapter_adapter_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Routes_Route); i {
 			case 0:
 				return &v.state
@@ -1158,7 +1227,7 @@ func file_api_adapter_adapter_proto_init() {
 				return nil
 			}
 		}
-		file_api_adapter_adapter_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+		file_api_adapter_adapter_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Listeners_Listener); i {
 			case 0:
 				return &v.state
@@ -1170,7 +1239,7 @@ func file_api_adapter_adapter_proto_init() {
 				return nil
 			}
 		}
-		file_api_adapter_adapter_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+		file_api_adapter_adapter_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Runtimes_Runtime); i {
 			case 0:
 				return &v.state
@@ -1182,7 +1251,7 @@ func file_api_adapter_adapter_proto_init() {
 				return nil
 			}
 		}
-		file_api_adapter_adapter_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+		file_api_adapter_adapter_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Secrets_Secret); i {
 			case 0:
 				return &v.state
@@ -1201,7 +1270,7 @@ func file_api_adapter_adapter_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_api_adapter_adapter_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/adapter/adapter.proto
+++ b/api/adapter/adapter.proto
@@ -63,6 +63,10 @@ message SetStateResponse {
   string message = 1;
 }
 
+message UpdateStateResponse {
+  string message = 1;
+}
+
 message clearRequest {
   string node = 1;
 }
@@ -73,5 +77,6 @@ message clearResponse {
 
 service Adapter {
   rpc SetState(Snapshot) returns (SetStateResponse){}
+  rpc UpdateState(Snapshot) returns (UpdateStateResponse){}
   rpc ClearState(clearRequest) returns (clearResponse) {}
 }

--- a/api/adapter/adapter_grpc.pb.go
+++ b/api/adapter/adapter_grpc.pb.go
@@ -19,6 +19,7 @@ const _ = grpc.SupportPackageIsVersion7
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type AdapterClient interface {
 	SetState(ctx context.Context, in *Snapshot, opts ...grpc.CallOption) (*SetStateResponse, error)
+	UpdateState(ctx context.Context, in *Snapshot, opts ...grpc.CallOption) (*UpdateStateResponse, error)
 	ClearState(ctx context.Context, in *ClearRequest, opts ...grpc.CallOption) (*ClearResponse, error)
 }
 
@@ -39,6 +40,15 @@ func (c *adapterClient) SetState(ctx context.Context, in *Snapshot, opts ...grpc
 	return out, nil
 }
 
+func (c *adapterClient) UpdateState(ctx context.Context, in *Snapshot, opts ...grpc.CallOption) (*UpdateStateResponse, error) {
+	out := new(UpdateStateResponse)
+	err := c.cc.Invoke(ctx, "/adapter.Adapter/UpdateState", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *adapterClient) ClearState(ctx context.Context, in *ClearRequest, opts ...grpc.CallOption) (*ClearResponse, error) {
 	out := new(ClearResponse)
 	err := c.cc.Invoke(ctx, "/adapter.Adapter/ClearState", in, out, opts...)
@@ -53,6 +63,7 @@ func (c *adapterClient) ClearState(ctx context.Context, in *ClearRequest, opts .
 // for forward compatibility
 type AdapterServer interface {
 	SetState(context.Context, *Snapshot) (*SetStateResponse, error)
+	UpdateState(context.Context, *Snapshot) (*UpdateStateResponse, error)
 	ClearState(context.Context, *ClearRequest) (*ClearResponse, error)
 	mustEmbedUnimplementedAdapterServer()
 }
@@ -63,6 +74,9 @@ type UnimplementedAdapterServer struct {
 
 func (UnimplementedAdapterServer) SetState(context.Context, *Snapshot) (*SetStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetState not implemented")
+}
+func (UnimplementedAdapterServer) UpdateState(context.Context, *Snapshot) (*UpdateStateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateState not implemented")
 }
 func (UnimplementedAdapterServer) ClearState(context.Context, *ClearRequest) (*ClearResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ClearState not implemented")
@@ -98,6 +112,24 @@ func _Adapter_SetState_Handler(srv interface{}, ctx context.Context, dec func(in
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Adapter_UpdateState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(Snapshot)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AdapterServer).UpdateState(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/adapter.Adapter/UpdateState",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AdapterServer).UpdateState(ctx, req.(*Snapshot))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Adapter_ClearState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ClearRequest)
 	if err := dec(in); err != nil {
@@ -126,6 +158,10 @@ var Adapter_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetState",
 			Handler:    _Adapter_SetState_Handler,
+		},
+		{
+			MethodName: "UpdateState",
+			Handler:    _Adapter_UpdateState_Handler,
 		},
 		{
 			MethodName: "ClearState",

--- a/examples/go-control-plane/adapter.go
+++ b/examples/go-control-plane/adapter.go
@@ -108,6 +108,18 @@ func (a *adapterServer) SetState (ctx context.Context, state *pb.Snapshot) (resp
 	return response, nil
 }
 
+func (a *adapterServer) UpdateState(ctx context.Context, state *pb.Snapshot) (*pb.UpdateStateResponse, error) {
+	response, err := a.SetState(ctx, state)
+	if err != nil {
+		fmt.Printf("Error setting state: %v", err)
+		return nil, err
+	}
+    updateResponse := &pb.UpdateStateResponse{
+    	Message: response.Message,
+    }
+	return updateResponse, err
+}
+
 func (a *adapterServer) ClearState(ctx context.Context, req *pb.ClearRequest) (*pb.ClearResponse, error) {
 	log.Printf("Clearing Cache")
 	xdsCache.ClearSnapshot(req.Node)

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -32,7 +32,6 @@ Feature: Fetching Resources with LDS and CDS
     And the Client sends an ACK to which the <service> does not respond
 
     Examples:
-      # Steps 3 and 5 should fail
       | service | starting version | next version | resources | expected resources | chosen resource |
       | "CDS"   | "1"              | "2"          | "A,B,C"   | "A,B,C"            | "A"             |
       | "CDS"   | "1"              | "2"          | "A,B,C"   | "C,A,B"            | "A"             |

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Fetching Resources with LDS and CDS
   Client can do wildcard subscriptions or normal subscriptions
   and receive updates when any subscribed resources change.
@@ -21,3 +20,23 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "D,E,F"            |
       | "LDS"   | "1"              | "D,E,F"   | "F,A,I,L"          |
       | "LDS"   | "1"              | "D,E,F"   | "F,D,E"            |
+
+
+  @wip
+  Scenario Outline: The service should send updates to the client
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client does a wildcard subscription to <service>
+    Then the client receives the <expected resources> and <starting version> for <service>
+    When <chosen resource> is updated to <next version>
+    Then the Client receives the <expected resources> and <next version> for <service>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      # Steps 3 and 5 should fail
+      | service | starting version | next version | resources | expected resources | chosen resource |
+      | "CDS"   | "1"              | "2"          | "A,B,C"   | "A,B,C"            | "A"             |
+      | "CDS"   | "1"              | "2"          | "A,B,C"   | "C,A,B"            | "A"             |
+      | "CDS"   | "1"              | "2"          | "A,B,C"   | "B,A,D"            | "A"             |
+      | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
+      | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,A,I,L"          | "D"             |
+      | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,D,E"            | "D"             |

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Fetching Resources with LDS and CDS
   Client can do wildcard subscriptions or normal subscriptions
   and receive updates when any subscribed resources change.
@@ -22,12 +23,11 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "F,D,E"            |
 
 
-  @wip
   Scenario Outline: The service should send updates to the client
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
     Then the client receives the <expected resources> and <starting version> for <service>
-    When <chosen resource> is updated to <next version>
+    When a <chosen resource> of the <service> is updated to the <next version>
     Then the Client receives the <expected resources> and <next version> for <service>
     And the Client sends an ACK to which the <service> does not respond
 
@@ -36,7 +36,7 @@ Feature: Fetching Resources with LDS and CDS
       | service | starting version | next version | resources | expected resources | chosen resource |
       | "CDS"   | "1"              | "2"          | "A,B,C"   | "A,B,C"            | "A"             |
       | "CDS"   | "1"              | "2"          | "A,B,C"   | "C,A,B"            | "A"             |
-      | "CDS"   | "1"              | "2"          | "A,B,C"   | "B,A,D"            | "A"             |
+      | "CDS"   | "1"              | "2"          | "A,B,C"   | "B,C,A"            | "A"             |
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
-      | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,A,I,L"          | "D"             |
+      | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,D,E"            | "D"             |

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func randomAddress() string {
+func RandomAddress() string {
 	var (
 		consonants = []rune("bcdfklmnprstwyz")
 		vowels     = []rune("aou")
@@ -54,7 +54,7 @@ func ToListeners (resources string) *pb.Listeners {
 	for _, name := range resourceNames {
 		listeners.Items = append(listeners.Items, &pb.Listeners_Listener{
 			Name: name,
-			Address: randomAddress(),
+			Address: RandomAddress(),
 		})
 	}
 	return listeners
@@ -118,7 +118,7 @@ func YamlToSnapshot(nodeID string, yml string) (*pb.Snapshot, error) {
 		for _, l := range s.Resources.Listeners {
 			listeners.Items = append(listeners.Items, &pb.Listeners_Listener{
 				Name: l.Name,
-				Address: randomAddress(),
+				Address: RandomAddress(),
 			})
 		}
 		snapshot.Listeners = listeners

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1,8 +1,5 @@
 package parser
 
-// type EnvoyNode struct {
-// 	ID string `yaml:"id"`
-// }
 type ConnectTimeout struct {
 	Seconds int64 `yaml:"seconds"`
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -35,6 +35,7 @@ type ClientConfig struct {
 
 type Cache struct {
 	StartState *pb.Snapshot
+	StateSnapshots []*pb.Snapshot
 	FinalResponse *discovery.DiscoveryResponse
 }
 

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -189,22 +189,54 @@ func (r *Runner) TheClientSendsAnACKToWhichTheDoesNotRespond(service string) err
 	return nil
 }
 
-func (r *Runner) IsUpdatedTo(arg1, arg2 string) error {
-        return godog.ErrPending
+func (r *Runner) ResourceOfTheServiceIsUpdatedToNextVersion(resource, service, version string) error {
+	log.Debug().
+		Msgf("Updating target state for %v resource %v", service, resource)
+
+	snapshot := r.Cache.StartState
+	snapshot.Version = version
+
+	if service == "LDS" {
+		listeners := snapshot.GetListeners()
+		for _, listener := range listeners.Items {
+			if listener.Name == resource {
+				listener.Address = parser.RandomAddress()
+			}
+		}
+		snapshot.Listeners = listeners
+	}
+
+	if service == "CDS" {
+		clusters := snapshot.GetClusters()
+		for _, cluster := range clusters.Items {
+			if cluster.Name == resource {
+				cluster.ConnectTimeout = map[string]int32{"seconds": 10}
+			}
+		}
+		snapshot.Clusters = clusters
+	}
+
+	c := pb.NewAdapterClient(r.Adapter.Conn)
+
+	_, err := c.UpdateState(context.Background(), snapshot)
+	if err != nil {
+		msg := "Cannot update target with given state"
+		log.Error().
+			Err(err).
+			Msg(msg)
+		return errors.New(msg)
+	}
+
+	r.Cache.StateSnapshots = append(r.Cache.StateSnapshots, snapshot)
+
+	return nil
 }
-
-func (r *Runner) TheClientReceivesTheAndFor(arg1, arg2, arg3 string) error {
-        return godog.ErrPending
-}
-
-
-
 
 func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
     ctx.Step(`^a target setup with "([^"]*)", "([^"]*)", and "([^"]*)"$`, r.ATargetSetupWithServiceResourcesAndVersion)
 	ctx.Step(`^the Client does a wildcard subscription to "([^"]*)"$`, r.TheClientDoesAWildcardSubscriptionToService)
     ctx.Step(`^the Client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersionForService)
 	ctx.Step(`^the Client sends an ACK to which the "([^"]*)" does not respond$`, r.TheClientSendsAnACKToWhichTheDoesNotRespond)
-	ctx.Step(`^"([^"]*)" is updated to "([^"]*)"$`, r.IsUpdatedTo)
-	ctx.Step(`^the client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesTheAndFor)
+    ctx.Step(`^a "([^"]*)" of the "([^"]*)" is updated to the "([^"]*)"$`, r.ResourceOfTheServiceIsUpdatedToNextVersion)
+	ctx.Step(`^the client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersionForService)
 }

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -189,10 +189,22 @@ func (r *Runner) TheClientSendsAnACKToWhichTheDoesNotRespond(service string) err
 	return nil
 }
 
+func (r *Runner) IsUpdatedTo(arg1, arg2 string) error {
+        return godog.ErrPending
+}
+
+func (r *Runner) TheClientReceivesTheAndFor(arg1, arg2, arg3 string) error {
+        return godog.ErrPending
+}
+
+
+
 
 func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
     ctx.Step(`^a target setup with "([^"]*)", "([^"]*)", and "([^"]*)"$`, r.ATargetSetupWithServiceResourcesAndVersion)
 	ctx.Step(`^the Client does a wildcard subscription to "([^"]*)"$`, r.TheClientDoesAWildcardSubscriptionToService)
     ctx.Step(`^the Client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersionForService)
 	ctx.Step(`^the Client sends an ACK to which the "([^"]*)" does not respond$`, r.TheClientSendsAnACKToWhichTheDoesNotRespond)
+	ctx.Step(`^"([^"]*)" is updated to "([^"]*)"$`, r.IsUpdatedTo)
+	ctx.Step(`^the client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesTheAndFor)
 }


### PR DESCRIPTION
This PR implements a test for making sure updates to a subscribed resource are sent from the server to the client.  It brings in a new RPC for the adapter, a new test step, and some small style tweaks to the test parser.

# Running the test

In one terminal window, from the root of this repo, run our target server:
```sh
go run examples/go-control-plane/main/main.go
```
Then, from the root of this repo, run the test suite, filtered to just this test:
```sh
go run . -t "@wip"
```

# Summary of changes
- **Added UpdateState rpc to adapter**
   The go control plane has a 'setState' method that lets you set or update the state without interruption to any subscribed clients, but I wasn't sure that would be the behaviour for all implementations.  It seemed a good idea for our adapter to have `setState, updateState, and clearState` as methods with clear intent that can be implemented however a target server would like.
- **Added an update step**
  This calls upon the new adapter method and does an arbitrary update on a resource.  For listeners it changes their socket address and for clusters it changes their connect timeout.
- **Cleaned up Parser**
  I removed some obsolete types and exported the parser's RandomAddress function so it could be used in our update step.