### PR TITLE
Test 3

### DIFF
--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -22,7 +22,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "F,D,E"            |
 
 
-  @wip
+
   Scenario Outline: The service should send updates to the client
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -39,6 +39,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,D,E"            | "D"             |
+
 
   @wip
   Scenario Outline: Wildcard subscriptions receive updates when new resources are added

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -39,3 +39,21 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,D,E"            | "D"             |
+
+  @wip
+  Scenario Outline: Wildcard subscriptions receive updates when new resources are added
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client does a wildcard subscription to <service>
+    Then the client receives the <resources> and <starting version> for <service>
+    When a <new resource> is added to the <service> with <next version>
+    Then the Client receives the <expected resources> and <next version> for <service>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      | service | starting version | resources | new resource | expected resources | next version |
+      | "CDS"   | "1"              | "A,B,C"   | "D"          | "A,B,C,D"          | "2"          |
+      | "CDS"   | "1"              | "A,B,C"   | "E"          | "A,B,C,E"          | "2"          |
+      | "CDS"   | "1"              | "A,B,C"   | "F"          | "A,B,C,F"          | "2"          |
+      | "LDS"   | "1"              | "D,E,F"   | "G"          | "D,E,F,G"          | "2"          |
+      | "LDS"   | "1"              | "D,E,F"   | "H"          | "D,E,F,H"          | "2"          |
+      | "LDS"   | "1"              | "D,E,F"   | "I"          | "D,E,F,I"          | "2"          |


### PR DESCRIPTION
This PR implements a test for making sure wildcard subscriptions receive updates when new resources are added to their subscribed service.  

# Running the test

In one terminal window, from the root of this repo, run our target server:
```sh
go run examples/go-control-plane/main/main.go
```
Then, from the root of this repo, run the test suite, filtered to just this test:
```sh
go run . -t "@wip"
```

All tests should pass.

# Summary of changes
- **Added a 'resource is added to service'  step**
  This uses the adapter's updateState method defined in #24 
- **Added third test**