### PR TITLE
implement test 4

### DIFF
--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -1,3 +1,4 @@
+  @wip
 Feature: Fetching Resources with LDS and CDS
   Client can do wildcard subscriptions or normal subscriptions
   and receive updates when any subscribed resources change.
@@ -60,7 +61,6 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "I"          | "D,E,F,I"          | "2"          |
 
 
-  @wip
   Scenario:  When subscribing to specific CDS resources, receive only these resources
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -41,7 +41,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "F,D,E"            | "D"             |
 
 
-  @wip
+
   Scenario Outline: Wildcard subscriptions receive updates when new resources are added
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -58,3 +58,21 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "G"          | "D,E,F,G"          | "2"          |
       | "LDS"   | "1"              | "D,E,F"   | "H"          | "D,E,F,H"          | "2"          |
       | "LDS"   | "1"              | "D,E,F"   | "I"          | "D,E,F,I"          | "2"          |
+
+
+  @wip
+  Scenario:  When subscribing to specific CDS resources, receive only these resources
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client subscribes to a <subset of resources> for <service>
+    Then the client receives the <subset of resources> and <starting version> for <service>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      # Test 5 should fail
+      | service | starting version | resources   | subset of resources |
+      | "CDS"   | "1"              | "A,B,C,D"   | "B,D"               |
+      | "CDS"   | "1"              | "B,C,A,"    | "C"                 |
+      | "CDS"   | "1"              | "F,A,B,C,D" | "A,C,D"             |
+      | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               |
+      | "LDS"   | "1"              | "B,L,G,"    | "L, H"              |
+      | "LDS"   | "1"              | "F,G,B,L,D" | "G,L,D"             |


### PR DESCRIPTION
Extends on the work done in #22 , #24 , and #25.  The setup steps are included in the description of those PR's, and so won't be redundant here.

This tests whether you can receive the specific requested resources.  There is an adjustment in our test steps.  We were only testing wildcard before, so we had a "subscribetoWildcard" step.  Here we are subscribing to a subset, but the only difference in the function is the resources included in the initial request.  I renamed the functions to simply `subscribeToLDS` or `subscribeToCDS`, and it works for wildcard or specified requests.