### PR TITLE
Tests 7 & 8

### DIFF
--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -120,6 +120,9 @@ Feature: Fetching Resources with LDS and CDS
 
   @wip
   Scenario: Client can unsubcribe from some resources
+    # This test does not check if the final results are only the subscribed resources
+    # it is valid(though not desired) for a server to send more than is requested.
+    # So the test will pass if client subscribes to A,B,C, unsubscribes from B,C and gets A,B,C back.
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
     Then the client receives the <subset of resources> and <starting version> for <service>

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -118,7 +118,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "F,G,B,L,D" | "G,L,D,Z"           | "D,G,L"         | "Z"             | "2"          |
 
 
-  @wip
+
   Scenario: Client can unsubcribe from some resources
     # This test does not check if the final results are only the subscribed resources
     # it is valid(though not desired) for a server to send more than is requested.
@@ -137,3 +137,19 @@ Feature: Fetching Resources with LDS and CDS
       | "CDS"   | "1"              | "F,A,B,C,D" | "C,A,B"             | "A,C"                |   "2"           |
       | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
       | "LDS"   | "1"              | "B,L,A,G,"  | "L,G,B"             | "L,G"                |   "2"           |
+
+
+  @wip
+  Scenario: Client can unsubcribe from all resources
+    # This is not working currently, the unsusbcribe is not registered,
+    # neither as an unsubscribe nor a new wildcard request
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client subscribes to a <subset of resources> for <service>
+    Then the client receives the <subset of resources> and <starting version> for <service>
+    When the Client unsubcribes from all resources for <service>
+    And a <subset of resources> of the <service> is updated to the <next version>
+    Then the Client does not receive any message from <service>
+
+    Examples:
+      | service | starting version | resources   | subset of resources | next version |
+      | "CDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -118,7 +118,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "F,G,B,L,D" | "G,L,D,Z"           | "D,G,L"         | "Z"             | "2"          |
 
 
-
+  @wip
   Scenario: Client can unsubcribe from some resources
     # This test does not check if the final results are only the subscribed resources
     # it is valid(though not desired) for a server to send more than is requested.

--- a/features/lds-cds.feature
+++ b/features/lds-cds.feature
@@ -99,7 +99,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "F,G,B,L,D" | "G,L,D"             | "D"                 | "2"          |
 
 
-  @wip
+
   Scenario: When subscribing to resources that don't exist, receive response when they are created
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -116,3 +116,21 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "B,D,X"             | "B,D"           | "X"             | "2"          |
       | "LDS"   | "1"              | "B,L,G,"    | "L,G,Y"             | "G,L"           | "Y"             | "2"          |
       | "LDS"   | "1"              | "F,G,B,L,D" | "G,L,D,Z"           | "D,G,L"         | "Z"             | "2"          |
+
+
+  @wip
+  Scenario: Client can unsubcribe from some resources
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client subscribes to a <subset of resources> for <service>
+    Then the client receives the <subset of resources> and <starting version> for <service>
+    When the Client updates subscription to a <resource from subset> of <service> with <starting version>
+    And a <resource from subset> of the <service> is updated to the <next version>
+    Then the Client receives the <resource from subset> and <next version> for <service>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      | service | starting version | resources   | subset of resources | resource from subset |   next version  |
+      | "CDS"   | "1"              | "A,B,C,D"   | "A,B"               | "A"                  |   "2"           |
+      | "CDS"   | "1"              | "F,A,B,C,D" | "C,A,B"             | "A,C"                |   "2"           |
+      | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
+      | "LDS"   | "1"              | "B,L,A,G,"  | "L,G,B"             | "L,G"                |   "2"           |

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -365,6 +365,7 @@ func (r *Runner) ClientUnsubcribesFromAllResourcesForService(service string) err
 
 	request := &discovery.DiscoveryRequest{
 		VersionInfo:   version,
+		ResourceNames: []string{""},
 		TypeUrl:       typeURL,
 	}
 	time.Sleep(3 * time.Second)

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -319,6 +319,33 @@ func (r *Runner) ClientSubscribesToASubsetOfResourcesForService(subset, service 
 	return nil
 }
 
+func (r *Runner) ClientUpdatesSubscriptionToAResourceForServiceWithVersion(resource, service,version string) error {
+	var stream *Service
+	var typeURL string
+
+	if service == "LDS" {
+		typeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
+		stream = r.LDS
+	}
+
+	if service == "CDS" {
+		typeURL = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+		stream = r.CDS
+	}
+
+	request := &discovery.DiscoveryRequest{
+		VersionInfo:   version,
+		ResourceNames: []string{resource},
+		TypeUrl:       typeURL,
+	}
+	time.Sleep(3 * time.Second)
+	log.Debug().Msgf("Sending Request: %v", request)
+	stream.Req <- request
+	time.Sleep(3 * time.Second)
+	return nil
+}
+
+
 func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
     ctx.Step(`^a target setup with "([^"]*)", "([^"]*)", and "([^"]*)"$`, r.ATargetSetupWithServiceResourcesAndVersion)
 	ctx.Step(`^the Client does a wildcard subscription to "([^"]*)"$`, r.TheClientDoesAWildcardSubscriptionToService)
@@ -328,4 +355,5 @@ func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
     ctx.Step(`^a "([^"]*)" of the "([^"]*)" is updated to the "([^"]*)"$`, r.ResourceOfTheServiceIsUpdatedToNextVersion)
 	ctx.Step(`^the client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersionForService)
     ctx.Step(`^a "([^"]*)" is added to the "([^"]*)" with "([^"]*)"$`, r.ResourceIsAddedToServiceWithVersion)
+    ctx.Step(`^the Client updates subscription to a "([^"]*)" of "([^"]*)" with "([^"]*)"$`, r.ClientUpdatesSubscriptionToAResourceForServiceWithVersion)
 }

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -143,6 +143,8 @@ func(r *Runner) ClientSubscribesToCDS (resources []string) error {
 	typeURL := "type.googleapis.com/envoy.config.cluster.v3.Cluster"
 	request := r.NewRequest(r.CDS.Cache.InitResource, typeURL)
 
+	log.Debug().
+		Msgf("Sending subscribing request: %v\n", request)
 	go r.CDSStream()
 	go r.Ack(request, r.CDS)
 	return nil
@@ -159,6 +161,8 @@ func (r *Runner) ClientSubscribesToLDS (resources []string) error {
 	typeURL := "type.googleapis.com/envoy.config.listener.v3.Listener"
 	request := r.NewRequest(r.LDS.Cache.InitResource, typeURL)
 
+	log.Debug().
+		Msgf("Sending subscribing request: %v\n", request)
 	go r.LDSStream()
 	go r.Ack(request, r.LDS)
 	return nil
@@ -338,11 +342,68 @@ func (r *Runner) ClientUpdatesSubscriptionToAResourceForServiceWithVersion(resou
 		ResourceNames: []string{resource},
 		TypeUrl:       typeURL,
 	}
-	time.Sleep(3 * time.Second)
 	log.Debug().Msgf("Sending Request: %v", request)
+	stream.Req <- request
+	return nil
+}
+
+func (r *Runner) ClientUnsubcribesFromAllResourcesForService(service string) error {
+	var stream *Service
+	var typeURL string
+
+	if service == "LDS" {
+		typeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
+		stream = r.LDS
+	}
+
+	if service == "CDS" {
+		typeURL = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+		stream = r.CDS
+	}
+
+	version := r.Cache.StartState.Version
+
+	request := &discovery.DiscoveryRequest{
+		VersionInfo:   version,
+		TypeUrl:       typeURL,
+	}
+	time.Sleep(3 * time.Second)
+	log.Debug().Msgf("Sending unsubscribe request: %v", request)
 	stream.Req <- request
 	time.Sleep(3 * time.Second)
 	return nil
+}
+
+func (r *Runner) ClientDoesNotReceiveAnyMessageFromService(service string) error {
+	var stream *Service
+
+	if service == "CDS" {
+		stream = r.CDS
+	}
+	if service == "LDS" {
+		stream = r.LDS
+	}
+
+	for {
+		select {
+		case err := <- stream.Err:
+			log.Err(err).Msg("From our step")
+			return err
+		default:
+			if len(stream.Cache.Responses) > 0 {
+				for _, response := range stream.Cache.Responses {
+					actual, err := parser.ParseDiscoveryResponseV2(response)
+					if err != nil {
+						log.Error().Err(err).Msg("can't parse discovery response ")
+						return err
+					}
+					err = errors.New("Received a response when we expected no response")
+					log.Err(err).Msgf("Response: %v",actual)
+					return err
+				}
+			}
+		}
+	}
 }
 
 
@@ -356,4 +417,6 @@ func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the client receives the "([^"]*)" and "([^"]*)" for "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersionForService)
     ctx.Step(`^a "([^"]*)" is added to the "([^"]*)" with "([^"]*)"$`, r.ResourceIsAddedToServiceWithVersion)
     ctx.Step(`^the Client updates subscription to a "([^"]*)" of "([^"]*)" with "([^"]*)"$`, r.ClientUpdatesSubscriptionToAResourceForServiceWithVersion)
+	ctx.Step(`^the Client does not receive any message from "([^"]*)"$`, r.ClientDoesNotReceiveAnyMessageFromService)
+	ctx.Step(`^the Client unsubcribes from all resources for "([^"]*)"$`, r.ClientUnsubcribesFromAllResourcesForService)
 }


### PR DESCRIPTION
This pair is intended to test unsubscribing from resources (See [LDS & CDS: test 7,8](https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E/edit#heading=h.jb0qcqxkhsx3))

At this moment, test 8 does not pass, but I am uncertain if it is in the target we are testing or how our tests are built.  I am only testing SoTW and using the go-control-plane as the target.  
I structured the test like so:
- I setup the target with multiple resources [A,B,C,D] and then have the client send an initial request for [A,B].  
 - I get a response back containing [A,B] and send an ACK. 
 - I send a new request with the same version and no nonce, and empty resource names (i've tried sending [""] and a fully blank value to not have it be confused with a wildcard request)
 - I update one of the resources, setting a new version for all that type's resources.

I expect to get either no response, or a response that includes [A,B,C,D].  The former indicates everything is working as expected, the latter indicates the control plane is interpreting my request as a wildcard.  Instead, I get an unexpected response containing [A,B]--which indicates the unsubscribe did not register in any way.

I am sure that there is a flaw in the logic of the test, but my eyes don't see it at the moment.  Would love more eyes on this to see where my gap in understanding might be!