### PR TITLE
Create entire instance with starting state

### DIFF
--- a/api/adapter/adapter.proto
+++ b/api/adapter/adapter.proto
@@ -4,47 +4,52 @@ option go_package = "github.com/zachmandeville/tester-prototype/adapter/adapter"
 
 package adapter;
 
+message Endpoint {
+  string name    = 1;
+  string cluster = 2;
+  string address = 3;
+}
+
+message Cluster {
+  string name                       = 1;
+  map<string,int32> connect_timeout = 2;
+}
+message Route {
+  string name = 1;
+}
+message Listener {
+  string name    = 1;
+  string address = 2;
+}
+message Runtime {
+  string name = 1;
+}
+
+message Secret {
+  string name = 1;
+}
+
 message Endpoints {
-  message Endpoint {
-    string name = 1;
-  }
   repeated Endpoint items = 1;
 }
 
 message Clusters {
-  message Cluster {
-    string name = 1;
-    map<string,int32> connect_timeout = 2;
-  }
   repeated Cluster items = 1;
 }
 
 message Routes {
-  message Route {
-    string name = 1;
-  }
   repeated Route items = 1;
 }
 
 message Listeners {
-  message Listener {
-    string name = 1;
-    string address = 2;
-  }
   repeated Listener items = 1;
 }
 
 message Runtimes {
-  message Runtime {
-    string name = 1;
-  }
   repeated Runtime items = 1;
 }
 
 message Secrets {
-  message Secret {
-    string name = 1;
-  }
   repeated Secret items = 1;
 }
 

--- a/diary/setting-state.org
+++ b/diary/setting-state.org
@@ -1,0 +1,42 @@
+#+TITLE: Setting State
+
+* Context and Goal
+
+All our tests begin with some specified state, meaning a configuration of an
+envoy instance that our test target can communicate with. While each test only
+cares about a single service, and so only cares about a single aspect of the
+configuration, it is becoming apparent that we need to set up the whole config
+during the initial setting of state.
+
+While we could do LDS and CDS tests by only adding listeners and clusters in our
+state, RDS and EDS require routes and endpoints that are tightly integrated with
+the rest of the system. It seems impossible to test RDS without setting up
+listeners and cluster first, for example.
+
+This diary tracks the reasoning and work for making our harness better set up
+for RDS and EDS and, in the future, secrets and runtimes.
+
+Success will be able to run a simple RDS test.
+
+*  Set some ground rules/assumptions
+- These rules are for SOTW. ADS will be handled differently.
+- We do not care about the content of our target. We are testing the transport
+  of info, not the info itself.
+- Our test harness should be opinionated about this.
+- A test only specifies resource names and a service.
+- The harness sets up 1 resource in each service for each given name.
+- The services are namespaced by typeurl, and so can have duplicate names. for example:
+  + The test calls for testing "RDS" with resources "[a,b,c]"
+  + Initial state has endpoints a,b,c; clusters a,b,c; listeners a,b,c; routes a,b,c; etc.
+  + Validation is only done for the RDS resources.
+- Each service resource has only enough info to be a valid configuration, with
+  the details handled by the harness.
+  + Clusters have a connect timeout set, but it's always 5 seconds.
+  + Listeners have an address set, but it's always a socket address with a name given by the harness.
+- When updating state, we only care about the version changing, not the contents of the update.
+* Process
+** Rewrite adapter types so all services represented
+** Rewrite our Given Step
+** Write RDS test
+** Test the given statement works
+** Test everything else works.

--- a/diary/setting-state.org
+++ b/diary/setting-state.org
@@ -36,7 +36,17 @@ Success will be able to run a simple RDS test.
 - When updating state, we only care about the version changing, not the contents of the update.
 * Process
 ** Rewrite adapter types so all services represented
+I will base the setup on the integration tests in the go-control-plane. I can
+start by defining it with all the details in those tests, reducing as we can to
+just the bare essentials.
+
+For most of the types i still can keep just the name, but sometimes need to specify the address.
+The routes and listeners both have random addresses assigned.
 ** Rewrite our Given Step
-** Write RDS test
-** Test the given statement works
-** Test everything else works.
+I updated the adapter in tegration into the go control plane by using functions already defined in GCP integration tests.
+Modelling our adapter off these tests let me set up the state successfully and all current tests that /should/ pass /do/ pass.
+** TODO Write RDS test
+** TODO Test the given statement works
+** TODO Test everything else works.
+* Questions
+1. Should there be a connection between the route socket address and the listener socket address? Does it matter?

--- a/examples/go-control-plane/adapter.go
+++ b/examples/go-control-plane/adapter.go
@@ -209,43 +209,31 @@ func MakeRuntime(runtimeName string) *runtime.Runtime {
 
 func (a *adapterServer) SetState(ctx context.Context, state *pb.Snapshot) (response *pb.SetStateResponse, err error) {
 
-	numClusters := len(state.Clusters.Items)
-	clusters := make([]types.Resource, numClusters)
-	for i := 0; i < numClusters; i++ {
-		cluster := state.Clusters.Items[i]
+	clusters := make([]types.Resource, len(state.Clusters.Items))
+	for i, cluster := range state.Clusters.Items {
 		clusters[i] = MakeCluster(cluster.Name, state.Node)
-
 	}
 
-	numEndpoints := len(state.Endpoints.Items)
-	endpoints := make([]types.Resource, numEndpoints)
-	for i := 0; i < numEndpoints; i++ {
-		endpoint := state.Endpoints.Items[i]
+	endpoints := make([]types.Resource, len(state.Endpoints.Items))
+	for i, endpoint := range state.Endpoints.Items {
 		endpoints[i] = MakeEndpoint(endpoint.Cluster, endpoint.Address, uint32(10000+i))
 	}
 
-	numRoutes := len(state.Routes.Items)
-	routes := make([]types.Resource, numRoutes)
-	// TODO grab the cluster from the route itself, by updating api?
-	for i := 0; i < numRoutes; i++ {
-		route := state.Routes.Items[i]
+	routes := make([]types.Resource, len(state.Routes.Items))
+	for i, route := range state.Routes.Items {
 		cluster := state.Clusters.Items[i]
 		routes[i] = MakeRoute(route.Name, cluster.Name)
 	}
 
-	numListeners := len(state.Listeners.Items)
-	listeners := make([]types.Resource, numListeners)
-	for i := 0; i < numListeners; i++ {
-		listener := state.Listeners.Items[i]
+	listeners := make([]types.Resource, len(state.Listeners.Items))
+	for i, listener := range state.Listeners.Items {
 		port := uint32(11000 + i)
 		route := state.Routes.Items[i]
 		listeners[i] = MakeRouteHTTPListener(state.Node, listener.Name, listener.Address, port, route.Name)
 	}
 
-	numRuntimes := len(state.Runtimes.Items)
-	runtimes := make([]types.Resource, numRuntimes)
-	for i := 0; i < numRuntimes; i++ {
-		runtime := state.Runtimes.Items[i]
+	runtimes := make([]types.Resource, len(state.Runtimes.Items))
+	for i, runtime := range state.Runtimes.Items {
 		runtimes[i] = MakeRuntime(runtime.Name)
 	}
 

--- a/examples/go-control-plane/adapter.go
+++ b/examples/go-control-plane/adapter.go
@@ -10,32 +10,31 @@ import (
 	"time"
 	"google.golang.org/grpc"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	pstruct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	runtime "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	pb "github.com/ii/xds-test-harness/api/adapter"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 )
 
 var (
 	xdsCache cache.SnapshotCache
+	localhost = "127.0.0.1"
 )
 
 type Clusters  map[string]*cluster.Cluster
 type Listeners map[string]*listener.Listener
+type Endpoints map[string]*endpoint.ClusterLoadAssignment
 
 type adapterServer struct {
 	pb.UnimplementedAdapterServer
-}
-
-
-func clusterContents(clusters Clusters) []types.Resource {
-	var r []types.Resource
-	for _, c := range clusters {
-		r = append(r, c)
-	}
-	return r
 }
 
 func listenerContents(listeners Listeners) []types.Resource {
@@ -45,48 +44,217 @@ func listenerContents(listeners Listeners) []types.Resource {
 	}
 	return r
 }
-
-func (a *adapterServer) SetState (ctx context.Context, state *pb.Snapshot) (response *pb.SetStateResponse, err error) {
-
-
-	// Parse Clusters
-	clusters := make(map[string]*cluster.Cluster)
-	if state.Clusters != nil {
-		for _, c := range state.Clusters.Items {
-			seconds := time.Duration(c.ConnectTimeout["seconds"])
-			clusters[c.Name] = &cluster.Cluster{
-				Name: c.Name,
-				ConnectTimeout: ptypes.DurationProto(seconds * time.Second),
-			}
-		}
-	}
-
-	// Parse Listeners
-	listeners := make(map[string]*listener.Listener)
-	if state.Listeners != nil {
-
-		for _, l := range state.Listeners.Items {
-			listeners[l.Name] = &listener.Listener{
-				Name:                             l.Name,
-				Address:                          &core.Address{
-					Address: &core.Address_SocketAddress{
-						SocketAddress: &core.SocketAddress{
-							Address: l.Address,
+// MakeEndpoint creates a localhost endpoint on a given port.
+func MakeEndpoint(clusterName string, address string, port uint32) *endpoint.ClusterLoadAssignment {
+	return &endpoint.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*endpoint.LocalityLbEndpoints{{
+			LbEndpoints: []*endpoint.LbEndpoint{{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Protocol: core.SocketAddress_TCP,
+									Address:  address,
+									PortSpecifier: &core.SocketAddress_PortValue{
+										PortValue: port,
+									},
+								},
+							},
 						},
 					},
 				},
-			}
+			}},
+		}},
+	}
+}
+
+func MakeCluster(clusterName string, node string) *cluster.Cluster {
+	edsSource := configSource(node)
+	connectTimeout := 5 * time.Second
+	return &cluster.Cluster{
+		Name:                 clusterName,
+		ConnectTimeout:       ptypes.DurationProto(connectTimeout),
+		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+		EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
+			EdsConfig: edsSource,
+		},
+	}
+}
+
+func MakeRoute(routeName, clusterName string) *route.RouteConfiguration {
+	return &route.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*route.VirtualHost{{
+			Name:    routeName,
+			Domains: []string{"*"},
+			Routes: []*route.Route{{
+				Match: &route.RouteMatch{
+					PathSpecifier: &route.RouteMatch_Prefix{
+						Prefix: "/",
+					},
+				},
+				Action: &route.Route_Route{
+					Route: &route.RouteAction{
+						ClusterSpecifier: &route.RouteAction_Cluster{
+							Cluster: clusterName,
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+// data source configuration
+func configSource(clusterName string) *core.ConfigSource {
+	source := &core.ConfigSource{}
+	source.ResourceApiVersion = core.ApiVersion_V3
+		source.ConfigSourceSpecifier = &core.ConfigSource_ApiConfigSource{
+			ApiConfigSource: &core.ApiConfigSource{
+				TransportApiVersion:       core.ApiVersion_V3,
+				ApiType:                   core.ApiConfigSource_GRPC,
+				SetNodeOnFirstMessageOnly: true,
+				GrpcServices: []*core.GrpcService{{
+					TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: clusterName},
+					},
+				}},
+			},
 		}
+	return source
+}
+
+func buildHttpConnectionManager() *hcm.HttpConnectionManager {
+	// HTTP filter configuration.
+	manager := &hcm.HttpConnectionManager{
+		CodecType:  hcm.HttpConnectionManager_AUTO,
+		StatPrefix: "http",
+		HttpFilters: []*hcm.HttpFilter{{
+			Name: wellknown.Router,
+		}},
+	}
+	return manager
+}
+
+func makeListener(listenerName string, address string, port uint32, filterChains []*listener.FilterChain) *listener.Listener {
+	return &listener.Listener{
+		Name: listenerName,
+		Address: &core.Address{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &core.SocketAddress{
+					Protocol: core.SocketAddress_TCP,
+					Address:  address,
+					PortSpecifier: &core.SocketAddress_PortValue{
+						PortValue: port,
+					},
+				},
+			},
+		},
+		FilterChains: filterChains,
+	}
+}
+
+func MakeRouteHTTPListener(clusterName string, listenerName string, listenerAddress string, port uint32, route string) *listener.Listener {
+	rdsSource := configSource(clusterName)
+	routeSpecifier := &hcm.HttpConnectionManager_Rds{
+		Rds: &hcm.Rds{
+			ConfigSource:    rdsSource,
+			RouteConfigName: route,
+		},
+	}
+
+	manager := buildHttpConnectionManager()
+	manager.RouteSpecifier = routeSpecifier
+
+	pbst, err := ptypes.MarshalAny(manager)
+	if err != nil {
+		panic(err)
+	}
+
+	filterChains := []*listener.FilterChain{
+		{
+			Filters: []*listener.Filter{
+				{
+					Name: wellknown.HTTPConnectionManager,
+					ConfigType: &listener.Filter_TypedConfig{
+						TypedConfig: pbst,
+					},
+				},
+			},
+		},
+	}
+
+	return makeListener(listenerName, listenerAddress, port, filterChains)
+}
+
+// MakeRuntime creates an RTDS layer with some fields.
+func MakeRuntime(runtimeName string) *runtime.Runtime {
+	return &runtime.Runtime{
+		Name: runtimeName,
+		Layer: &pstruct.Struct{
+			Fields: map[string]*pstruct.Value{
+				"field-0": {
+					Kind: &pstruct.Value_NumberValue{NumberValue: 100},
+				},
+				"field-1": {
+					Kind: &pstruct.Value_StringValue{StringValue: "foobar"},
+				},
+			},
+		},
+	}
+}
+
+func (a *adapterServer) SetState (ctx context.Context, state *pb.Snapshot) (response *pb.SetStateResponse, err error) {
+
+	numClusters := len(state.Clusters.Items)
+	clusters := make([]types.Resource, numClusters)
+	for i := 0; i < numClusters; i++ {
+		cluster := state.Clusters.Items[i]
+		clusters[i] = MakeCluster(cluster.Name, state.Node)
+
+	}
+
+	numEndpoints := len(state.Endpoints.Items)
+	endpoints := make([]types.Resource, numEndpoints)
+	for i := 0; i < numEndpoints; i++ {
+  	    endpoint:= state.Endpoints.Items[i]
+		endpoints[i] = MakeEndpoint(endpoint.Cluster, endpoint.Address, uint32(10000+i))
+	}
+
+	numRoutes := len(state.Routes.Items)
+	routes := make([]types.Resource, numRoutes)
+	// TODO grab the cluster from the route itself, by updating api?
+	for i := 0; i < numRoutes; i++ {
+		route := state.Routes.Items[i]
+		cluster := state.Clusters.Items[i]
+		routes[i] = MakeRoute(route.Name, cluster.Name)
+	}
+
+	numListeners := len(state.Listeners.Items)
+	listeners := make([]types.Resource, numListeners)
+	for i := 0; i < numListeners; i++ {
+		listener := state.Listeners.Items[i]
+		port := uint32(11000 + i)
+		route := state.Routes.Items[i]
+		listeners[i] = MakeRouteHTTPListener(state.Node, listener.Name, listener.Address, port, route.Name)
+	}
+
+	numRuntimes := len(state.Runtimes.Items)
+	runtimes := make([]types.Resource, numRuntimes)
+	for i := 0; i < numRuntimes; i++ {
+		runtime := state.Runtimes.Items[i]
+		runtimes[i] = MakeRuntime(runtime.Name)
 	}
 
 	snapshot := cache.NewSnapshot(
 		state.Version,
-		// p.xdsCache.EndpointsContents(),
-		[]types.Resource{}, // endpoints
-		clusterContents(clusters), // clusters
-		[]types.Resource{}, // routes
-		listenerContents(listeners),
-		[]types.Resource{}, // runtimes
+		endpoints,
+		clusters,
+		routes,
+		listeners,
+		runtimes,
 		[]types.Resource{}, // secrets
 	)
 	if err = snapshot.Consistent(); err != nil {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -15,9 +15,9 @@ func RandomAddress() string {
 	var (
 		consonants = []rune("bcdfklmnprstwyz")
 		vowels     = []rune("aou")
-		tld = []string{".biz",".com",".net",".org"}
+		tld        = []string{".biz", ".com", ".net", ".org"}
 
-		domain     = ""
+		domain = ""
 	)
 	rand.Seed(time.Now().UnixNano())
 	length := 6 + rand.Intn(12)
@@ -35,7 +35,7 @@ func ToEndpoints(resourceNames []string) *pb.Endpoints {
 	endpoints := &pb.Endpoints{}
 	for _, name := range resourceNames {
 		endpoints.Items = append(endpoints.Items, &pb.Endpoint{
-			Name: name,
+			Name:    name,
 			Cluster: name,
 			Address: RandomAddress(),
 		})
@@ -47,7 +47,7 @@ func ToClusters(resourceNames []string) *pb.Clusters {
 	clusters := &pb.Clusters{}
 	for _, name := range resourceNames {
 		clusters.Items = append(clusters.Items, &pb.Cluster{
-			Name: name,
+			Name:           name,
 			ConnectTimeout: map[string]int32{"seconds": 5},
 		})
 	}
@@ -64,18 +64,18 @@ func ToRoutes(resourceNames []string) *pb.Routes {
 	return routes
 }
 
-func ToListeners (resourceNames []string) *pb.Listeners {
+func ToListeners(resourceNames []string) *pb.Listeners {
 	listeners := &pb.Listeners{}
 	for _, name := range resourceNames {
 		listeners.Items = append(listeners.Items, &pb.Listener{
-			Name: name,
+			Name:    name,
 			Address: RandomAddress(),
 		})
 	}
 	return listeners
 }
 
-func ToRuntimes (resourceNames []string) *pb.Runtimes {
+func ToRuntimes(resourceNames []string) *pb.Runtimes {
 	runtimes := &pb.Runtimes{}
 	for _, name := range resourceNames {
 		runtimes.Items = append(runtimes.Items, &pb.Runtime{
@@ -85,7 +85,7 @@ func ToRuntimes (resourceNames []string) *pb.Runtimes {
 	return runtimes
 }
 
-func ToSecrets (resourceNames []string) *pb.Secrets {
+func ToSecrets(resourceNames []string) *pb.Secrets {
 	secrets := &pb.Secrets{}
 	for _, name := range resourceNames {
 		secrets.Items = append(secrets.Items, &pb.Secret{
@@ -95,7 +95,7 @@ func ToSecrets (resourceNames []string) *pb.Secrets {
 	return secrets
 }
 
-func ParseDiscoveryResponseV2 (res *envoy_service_discovery_v3.DiscoveryResponse) (*SimpleResponse, error) {
+func ParseDiscoveryResponseV2(res *envoy_service_discovery_v3.DiscoveryResponse) (*SimpleResponse, error) {
 	simpRes := &SimpleResponse{}
 
 	simpRes.Version = res.VersionInfo
@@ -104,7 +104,7 @@ func ParseDiscoveryResponseV2 (res *envoy_service_discovery_v3.DiscoveryResponse
 
 	if res.TypeUrl == "type.googleapis.com/envoy.config.listener.v3.Listener" {
 		for _, resource := range res.GetResources() {
-		    listener := &listener.Listener{}
+			listener := &listener.Listener{}
 			if err := resource.UnmarshalTo(listener); err != nil {
 				fmt.Printf("ERORROROROR: %v", err)
 				return nil, err
@@ -114,7 +114,7 @@ func ParseDiscoveryResponseV2 (res *envoy_service_discovery_v3.DiscoveryResponse
 	}
 	if res.TypeUrl == "type.googleapis.com/envoy.config.cluster.v3.Cluster" {
 		for _, resource := range res.GetResources() {
-		    cluster := &cluster.Cluster{}
+			cluster := &cluster.Cluster{}
 			if err := resource.UnmarshalTo(cluster); err != nil {
 				fmt.Printf("ERORROROROR: %v", err)
 				return nil, err

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -32,10 +31,20 @@ func RandomAddress() string {
 	return domain + tld[rand.Intn(len(tld))]
 }
 
-func ToClusters(resources string) *pb.Clusters {
-	resourceNames := strings.Split(resources, ",")
-	clusters := &pb.Clusters{}
+func ToEndpoints(resourceNames []string) *pb.Endpoints {
+	endpoints := &pb.Endpoints{}
+	for _, name := range resourceNames {
+		endpoints.Items = append(endpoints.Items, &pb.Endpoint{
+			Name: name,
+			Cluster: name,
+			Address: RandomAddress(),
+		})
+	}
+	return endpoints
+}
 
+func ToClusters(resourceNames []string) *pb.Clusters {
+	clusters := &pb.Clusters{}
 	for _, name := range resourceNames {
 		clusters.Items = append(clusters.Items, &pb.Cluster{
 			Name: name,
@@ -45,10 +54,18 @@ func ToClusters(resources string) *pb.Clusters {
 	return clusters
 }
 
-func ToListeners (resources string) *pb.Listeners {
-	resourceNames := strings.Split(resources, ",")
-	listeners := &pb.Listeners{}
+func ToRoutes(resourceNames []string) *pb.Routes {
+	routes := &pb.Routes{}
+	for _, name := range resourceNames {
+		routes.Items = append(routes.Items, &pb.Route{
+			Name: name,
+		})
+	}
+	return routes
+}
 
+func ToListeners (resourceNames []string) *pb.Listeners {
+	listeners := &pb.Listeners{}
 	for _, name := range resourceNames {
 		listeners.Items = append(listeners.Items, &pb.Listener{
 			Name: name,
@@ -56,6 +73,26 @@ func ToListeners (resources string) *pb.Listeners {
 		})
 	}
 	return listeners
+}
+
+func ToRuntimes (resourceNames []string) *pb.Runtimes {
+	runtimes := &pb.Runtimes{}
+	for _, name := range resourceNames {
+		runtimes.Items = append(runtimes.Items, &pb.Runtime{
+			Name: name,
+		})
+	}
+	return runtimes
+}
+
+func ToSecrets (resourceNames []string) *pb.Secrets {
+	secrets := &pb.Secrets{}
+	for _, name := range resourceNames {
+		secrets.Items = append(secrets.Items, &pb.Secret{
+			Name: name,
+		})
+	}
+	return secrets
 }
 
 func ParseDiscoveryResponseV2 (res *envoy_service_discovery_v3.DiscoveryResponse) (*SimpleResponse, error) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -9,9 +9,7 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/ptypes"
 	pb "github.com/ii/xds-test-harness/api/adapter"
-	"gopkg.in/yaml.v2"
 )
 
 func RandomAddress() string {
@@ -39,7 +37,7 @@ func ToClusters(resources string) *pb.Clusters {
 	clusters := &pb.Clusters{}
 
 	for _, name := range resourceNames {
-		clusters.Items = append(clusters.Items, &pb.Clusters_Cluster{
+		clusters.Items = append(clusters.Items, &pb.Cluster{
 			Name: name,
 			ConnectTimeout: map[string]int32{"seconds": 5},
 		})
@@ -52,123 +50,12 @@ func ToListeners (resources string) *pb.Listeners {
 	listeners := &pb.Listeners{}
 
 	for _, name := range resourceNames {
-		listeners.Items = append(listeners.Items, &pb.Listeners_Listener{
+		listeners.Items = append(listeners.Items, &pb.Listener{
 			Name: name,
 			Address: RandomAddress(),
 		})
 	}
 	return listeners
-}
-
-func YamlToDesiredState(yml string) (*Snapshot, error) {
-	var s *Snapshot
-	err := yaml.Unmarshal([]byte(yml), &s)
-	return s, err
-}
-
-func ParseResourceList(resources string)  ([]string, error) {
-	var resourceList []string
-	err := yaml.Unmarshal([]byte(resources), &resourceList)
-	return resourceList, err
-}
-
-func YamlToSnapshot(nodeID string, yml string) (*pb.Snapshot, error) {
-	s, err := YamlToDesiredState(yml)
-	if err != nil {
-		return nil, err
-	}
-
-	snapshot := &pb.Snapshot{
-		Node:    nodeID,
-		Version: s.Version,
-	}
-	if s.Resources.Endpoints != nil {
-		endpoints := &pb.Endpoints{}
-		for _, e := range s.Resources.Endpoints {
-			endpoints.Items = append(endpoints.Items, &pb.Endpoints_Endpoint{
-				Name: e.Name,
-			})
-		}
-		snapshot.Endpoints = endpoints
-	}
-
-	if s.Resources.Clusters != nil {
-		clusters := &pb.Clusters{}
-		for _, c := range s.Resources.Clusters {
-			clusters.Items = append(clusters.Items, &pb.Clusters_Cluster{
-				Name:           c.Name,
-				ConnectTimeout: map[string]int32{"seconds": 5},
-			})
-		}
-		snapshot.Clusters = clusters
-	}
-
-	if s.Resources.Routes != nil {
-		routes := &pb.Routes{}
-		for _, r := range s.Resources.Routes {
-			routes.Items = append(routes.Items, &pb.Routes_Route{
-				Name: r.Name,
-			})
-		}
-	}
-
-	if s.Resources.Listeners != nil {
-		fmt.Println("snap listeners", s.Resources.Listeners)
-		listeners := &pb.Listeners{}
-		for _, l := range s.Resources.Listeners {
-			listeners.Items = append(listeners.Items, &pb.Listeners_Listener{
-				Name: l.Name,
-				Address: RandomAddress(),
-			})
-		}
-		snapshot.Listeners = listeners
-	}
-
-	if s.Resources.Runtimes != nil {
-		runtime := &pb.Runtimes{}
-		for _, r := range s.Resources.Runtimes {
-			runtime.Items = append(runtime.Items, &pb.Runtimes_Runtime{
-				Name: r.Name,
-			})
-		}
-	}
-
-	if s.Resources.Secrets != nil {
-		secret := &pb.Secrets{}
-		for _, s := range s.Resources.Secrets {
-			secret.Items = append(secret.Items, &pb.Secrets_Secret{
-				Name: s.Name,
-			})
-		}
-	}
-
-	return snapshot, nil
-}
-
-func ParseDiscoveryResponse(dr *envoy_service_discovery_v3.DiscoveryResponse) (*DiscoveryResponse, error) {
-	response := DiscoveryResponse{
-		VersionInfo: dr.GetVersionInfo(),
-		TypeURL:     dr.GetTypeUrl(),
-		Resources:   []Cluster{},
-		Nonce:       dr.GetNonce(),
-	}
-	for i := range dr.GetResources() {
-		var cpb cluster.Cluster
-		err := ptypes.UnmarshalAny(dr.GetResources()[i], &cpb)
-		if err != nil {
-			fmt.Printf("anypb error: %v\n", err)
-		}
-		// TODO: why is this necessary?
-		cc := Cluster{
-			Name: cpb.Name,
-			ConnectTimeout: ConnectTimeout{
-				Seconds: cpb.ConnectTimeout.Seconds,
-			},
-		}
-
-		response.Resources = append(response.Resources, cc)
-	}
-	return &response, nil
 }
 
 func ParseDiscoveryResponseV2 (res *envoy_service_discovery_v3.DiscoveryResponse) (*SimpleResponse, error) {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -6,8 +6,8 @@ type ConnectTimeout struct {
 
 type Endpoint struct {
 	Name    string `yaml:"name"`
+	Cluster string `yaml:"cluster"`
 	Address string `yaml:"address"`
-	Port    uint32 `yaml:"port"`
 }
 
 type Cluster struct {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -61,7 +61,7 @@ type DiscoveryResponse struct {
 
 type SimpleResponse struct {
 	// Only the info used for validating our tests
-	Version string
+	Version   string
 	Resources []string
-	Nonce string
+	Nonce     string
 }

--- a/internal/runner/services.go
+++ b/internal/runner/services.go
@@ -6,33 +6,33 @@ import (
 	"time"
 	// core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	cds "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
-	lds "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	lds "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	"google.golang.org/grpc"
 )
 
 const (
-	TypeUrlLDS= "type.googleapis.com/envoy.config.listener.v3.Listener"
+	TypeUrlLDS = "type.googleapis.com/envoy.config.listener.v3.Listener"
 	TypeUrlCDS = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
 	// TYPEURL_RDS = ""
 )
 
 type Channels struct {
-	Req   chan *discovery.DiscoveryRequest
-	Res   chan *discovery.DiscoveryResponse
-	Err   chan error
-	Done  chan bool
+	Req  chan *discovery.DiscoveryRequest
+	Res  chan *discovery.DiscoveryResponse
+	Err  chan error
+	Done chan bool
 }
 
 type ServiceCache struct {
 	InitResource []string
-	Requests  []*discovery.DiscoveryRequest
-	Responses []*discovery.DiscoveryResponse
+	Requests     []*discovery.DiscoveryRequest
+	Responses    []*discovery.DiscoveryResponse
 }
 
 type Context struct {
 	context context.Context
-	cancel context.CancelFunc
+	cancel  context.CancelFunc
 }
 
 type Stream interface {
@@ -41,14 +41,13 @@ type Stream interface {
 	CloseSend() error
 }
 
-
 type XDSService struct {
-	Name string
-	TypeURL string
+	Name     string
+	TypeURL  string
 	Channels *Channels
-	Cache *ServiceCache
-	Stream Stream
-	Context Context
+	Cache    *ServiceCache
+	Stream   Stream
+	Context  Context
 }
 
 type serviceBuilder interface {
@@ -56,19 +55,18 @@ type serviceBuilder interface {
 	setStream(conn *grpc.ClientConn) error
 	setInitResources([]string)
 	getService() *XDSService
-
 }
 
 type LDSBuilder struct {
-	Name string
-	TypeURL string
+	Name     string
+	TypeURL  string
 	Channels *Channels
-	Cache *ServiceCache
-	Stream Stream
-	Context Context
+	Cache    *ServiceCache
+	Stream   Stream
+	Context  Context
 }
 
-func (b *LDSBuilder) openChannels () {
+func (b *LDSBuilder) openChannels() {
 	b.Channels = &Channels{
 		Req:  make(chan *discovery.DiscoveryRequest, 2),
 		Res:  make(chan *discovery.DiscoveryResponse, 2),
@@ -76,7 +74,6 @@ func (b *LDSBuilder) openChannels () {
 		Done: make(chan bool),
 	}
 }
-
 
 func (b *LDSBuilder) setStream(conn *grpc.ClientConn) error {
 	client := lds.NewListenerDiscoveryServiceClient(conn)
@@ -92,31 +89,31 @@ func (b *LDSBuilder) setStream(conn *grpc.ClientConn) error {
 	return nil
 }
 
-func (b *LDSBuilder) setInitResources (res []string) {
+func (b *LDSBuilder) setInitResources(res []string) {
 	b.Cache = &ServiceCache{}
 	b.Cache.InitResource = res
 }
 
-func (b *LDSBuilder) getService () *XDSService {
+func (b *LDSBuilder) getService() *XDSService {
 	return &XDSService{
 		Name:     "LDS",
 		TypeURL:  TypeUrlLDS,
 		Channels: b.Channels,
-		Cache: b.Cache,
-		Stream: b.Stream,
+		Cache:    b.Cache,
+		Stream:   b.Stream,
 	}
 }
 
 type CDSBuilder struct {
-	Name string
-	TypeURL string
+	Name     string
+	TypeURL  string
 	Channels *Channels
-	Cache *ServiceCache
-	Stream Stream
-	Context Context
+	Cache    *ServiceCache
+	Stream   Stream
+	Context  Context
 }
 
-func (b *CDSBuilder) openChannels () {
+func (b *CDSBuilder) openChannels() {
 	b.Channels = &Channels{
 		Req:  make(chan *discovery.DiscoveryRequest, 2),
 		Res:  make(chan *discovery.DiscoveryResponse, 2),
@@ -124,7 +121,6 @@ func (b *CDSBuilder) openChannels () {
 		Done: make(chan bool),
 	}
 }
-
 
 func (b *CDSBuilder) setStream(conn *grpc.ClientConn) error {
 	client := cds.NewClusterDiscoveryServiceClient(conn)
@@ -140,18 +136,18 @@ func (b *CDSBuilder) setStream(conn *grpc.ClientConn) error {
 	return nil
 }
 
-func (b *CDSBuilder) setInitResources (res []string) {
+func (b *CDSBuilder) setInitResources(res []string) {
 	b.Cache = &ServiceCache{}
 	b.Cache.InitResource = res
 }
 
-func (b *CDSBuilder) getService () *XDSService {
+func (b *CDSBuilder) getService() *XDSService {
 	return &XDSService{
 		Name:     "CDS",
 		TypeURL:  TypeUrlCDS,
 		Channels: b.Channels,
-		Cache: b.Cache,
-		Stream: b.Stream,
+		Cache:    b.Cache,
+		Stream:   b.Stream,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -6,20 +6,19 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
+	pb "github.com/ii/xds-test-harness/api/adapter"
 	"github.com/ii/xds-test-harness/internal/runner"
-	"github.com/spf13/pflag"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	pb "github.com/ii/xds-test-harness/api/adapter"
-
+	"github.com/spf13/pflag"
 )
 
 var (
-	debug  = pflag.BoolP("debug", "D", false, "sets log level to debug")
-	adapterAddress  = pflag.StringP("adapter", "A", ":17000", "port of adapter on target")
+	debug          = pflag.BoolP("debug", "D", false, "sets log level to debug")
+	adapterAddress = pflag.StringP("adapter", "A", ":17000", "port of adapter on target")
 	targetAddress  = pflag.StringP("target", "T", ":18000", "port of xds target to test")
-	nodeID  = pflag.StringP("nodeID", "N", "test-id", "node id of target")
-    ADS = pflag.StringP("ADS", "X", "on", "Whether to include ADS tests, or only run ADS tests. Can be: on, off, or only.")
+	nodeID         = pflag.StringP("nodeID", "N", "test-id", "node id of target")
+	ADS            = pflag.StringP("ADS", "X", "on", "Whether to include ADS tests, or only run ADS tests. Can be: on, off, or only.")
 
 	godogOpts = godog.Options{
 		ShowStepDefinitions: false,
@@ -50,7 +49,7 @@ func InitializeTestSuite(sc *godog.TestSuiteContext) {
 			log.Fatal().
 				Msgf("error connecting to target: %v", err)
 		}
-		if err := r.ConnectClient("adapter",*adapterAddress); err != nil {
+		if err := r.ConnectClient("adapter", *adapterAddress); err != nil {
 			log.Fatal().
 				Msgf("error connecting to adapter: %v", err)
 		}


### PR DESCRIPTION
This is a semi-major adjustment to how we set up our target via the adapter.  Previously we only set up enough state to pass the current service's test.  As we move into new services though that are integrated with other services (e.g. RDS), we need to set up the entire instance's state to work properly.

So now, if you have a test like:
```
given a Target with CDS  with cluster resources "A,B,C"
```
the test harness will set up an instance with CDS...but also EDS, RDS,LDS,RTDS, and SDS.  each service will have resources A,B,C (namespaced and configured to  that particular type).  The remainder of the test will still only be for CDS.

At the moment, all our current tests pass with this change.  I am sure the change could be cleaner, which is why this is a draft, but this works as a proof of concept.