### PR TITLE
Add ADS Support

### DIFF
--- a/diary/ads-support.org
+++ b/diary/ads-support.org
@@ -48,30 +48,29 @@ A person should only start the runner once, and then the runner executes the
 test suite against the different set variants, by running the right stream
 against each of the supported, appropriate RPC methods (as outlined above).
 
-A person can indicate which variants their target supports using the flag
-~--variants~. This flag expects a four character stirng made up of 1's and 0's.
-1 represents support, 0 non-support. The variants are, right to left, sotw
-non-agg, sotw agg, incremental non-agg, incremental agg.
+A person can indicate which variants their target supports using the ~--variant~
+flag. You can invoke the flag with a variant name to include it in the suite—
+invoking it multiple times per variant your server supports.
 
-So if a person wanted to run the test suite against a server
-running only non-aggregated, but supporting sotw and incremental, they'd run:
-: ./runner --variants 1010
+#+begin_example
+./runner \
+--variant "sotw non-aggregated" \
+--variant "incremental aggregated"
+#+end_example
 
-If they are an edge case that only supports SoTW, non-aggregated and
-incremental, aggregated, then they'd run:
-: ./runner --variants 1001
+
 *** Tagging  the tests
 For the tests themselves, some may be general enough to work across all
 variants, and some may only be appropriate for a particular combination. We can
 indicate this using [[https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L8][tags added to the top of the test scenario]]. The tags are:
 - @sotw
 - @incremental
-- @aggregate
-- @separate
+- @aggregated
+- @non-aggregated
 *** reading flags and tags in our main
-In our main function, we [[https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L101][parse the variant flag]] to build an array of boolean values.
-For each true value in the array, we [[https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L152][run the test suite]] for that variant. This means
-the suite can run from 1-4 times.
+In our main function, we [[https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L98][parse the variant flag]] to build a map of variants and
+whether they're supported. For each true value in the array, we [[https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L147][run the test
+suite]] for that variant. This means the suite can run from 1-4 times.
 
 *** Changes to our test Steps
 
@@ -83,51 +82,39 @@ or update state as nceeded.
 
 We can use the same pattern for ADS, with some modifications:
 
-Originally, the service interface included its typeURL value.
-When we needed to make a new request, we'd use the service's assign typeURL.
-This doesn't work for ADs, so now [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L102][our new request functions pass the required
-typeURL]], which is determined from the test step itself.
+Originally, the service interface included its typeURL value. When we needed to
+make a new request, we'd use the service's assign typeURL. This doesn't work for
+ADs, so now we pass the type to the runner from the step itself.
 
 Originally, our subscribing step assumed you would be doing one subscription per
 scenario, and so built a service interface as part of the subscription step.
 This doesn't work for ADS-Only tests where you are subscribing to multiple
 services across the same stream, and building a new service interface means
-clearing the existing caches. Now, the subscribing function [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L107][checks if we
-already]] have a service initialized and, if so, uses its existing inferface. I
-think this change makes the function stronger overall, and may help me fix the
+clearing the existing caches. Now, the subscribing function checks if we already
+have a service initialized and, if so, uses its existing inferface. I think this
+change makes the function stronger overall, and may help me fix the
 unsubscribing issues.
 
 *** Uncertain changes
-I added a new step at the end of our ADS-only test, that reads:
-[[https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L192]["And the server never responds more than necessary"]].
+I added a new step at the end of our ADS-only test, that reads: [[https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L192]["And the server
+never responds more than necessary"]]. This line points to our existing testing
+function for "And the client ACKS to which the server does not respond".
 
-This step is functionally identical to our current step [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L257]["And the client ACKS to
-which the server does not respond".]]
+For all our existing tests, we set up the test environment so the server always
+sends back a valid response and our test runner always ACKS every response it
+gets. The server should not respond to an ACK. Because of this built-in logic,
+if the server has not responded to an ACK, then there should always be at least
+one more request from the client than there is response from server (e.g. the
+final ACK the client sent).
 
-I duplicated the function due to an issue in the function's logic. It closes
-down our response and request channels, so that any remaining messages can come
-through and we can look at the entire range of messages sent. Then, we count
-the # of responses and # of requests. Since ACK'ing is built into the client's
-lifecycle, and it is acking every response it gets from the server, than in this
-final step there should be 1 more request than response. If not, the step fails.
+Because of this, our test step runs at the end, closes the channels so no more
+requests or responses can be sent, and then verifies that the request count is
+higher than the response count. This step, then, should run at the end of the
+scenario.
 
-This logic requires the step to be run at the end of the test. However, in the
-test cases doc, for the ADS-only test there are multiple "and the client sends
-an ack to which the server doesn't respond". If I tried to match the test case
-verbatim, we'd be closing the ADS stream too early. If I just put the existing
-step at the end, it seems as if we are only ACK'ing once.
+With the ADS-Only test, the client is acking alot more than at the end of the
+step. I wanted to be as clear as possible, and so adjusted the wording.
 
-Now, the ACK'ing is assumed to happen as part of the test, and we just check at
-the end that the server hasn't sent more responses than it needed to. I worry
-this makes the test steps too opaque, and it may be highlighting that the
-existing steps are not as elegant as they could be. I am v. open for feedback or
-suggestions on if this needs to change, and how it could be improved.
-** Process
-*** DONE Implement hook for switching between variants
-*** DONE Refactor functions as necessary
-*** DONE Write ADS only test
-*** TODO Celebrate and Dance
-** Questions
-- Does the wording of the ADS test work for everyone?
-  + does the test run as we'd expect?
-- Are there any objections/improvements to the --variants flag?
+In a situation where we want to test error handling on the client, or the server
+sending out a new response from a stale nonce, we will use new functions that
+test for these specific environments.

--- a/diary/ads-support.org
+++ b/diary/ads-support.org
@@ -1,6 +1,6 @@
 #+TITLE: Ads Support
 #+DATE: 2021-01-18
-#+AUTHOR: Zach Mandeville
+#+AUTHOR: Zach Mandeville, Mark Roth
 
 ** Introduction
 This diary is a work-in-progress, documenting how we add ADS support to the xDS
@@ -11,52 +11,80 @@ The bottom of the document has open questions for which I'd love feedback. When
 a question is answered, it'll be removed from that section and its answer woven
 into this diary.
 
-** Assumptions/Current Understanding
-- The xDS transport protocol has [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol][four variants]]. An xDS server can handle any or
-  all of these variants.
-- The test framework, too, should cover all variants.
-  + It [[https://github.com/ii/xds-test-harness/tree/de750b5ba26ba3f0de5a6ecca1fcac20b787ee30][currently]] only supports SoTW(State of the World)/Basic
-  + SoTW/ADS(Aggregated Discovery) should be the added next, followed by Delta/Basic and Delta/ADS.
-- An xDS server is configured for a single variant on startup
-  + e.g: if it's set to SoTW/ADS, then all CDS,LDS,RDS,EDS features will be handled
-    via ADS
-  + It cannot switch itself from basic to ADS and remain running.
-- The intent of our current tests are the same, no matter if a server is
-  configured as basic or aggregated.
-  + However, there will be additional 'ADS-only' tests
-- A team may want to ensure their server can handle basic /and/ ADS.
-- **The framework should be able to be configured for a server's configuration, a configuration that holds through the entire test suite.**
-- **If a team wants to test their server with multiple configurations, they should run the test suite multiple times, once per configuration.**
+** Background
+The xDS transport protocol has [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol][four variants]]. Each of the variants are handled
+by [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#rpc-services-and-methods-for-each-variant][different RPC services/methods]], and so an xDS server can support any or all
+of them at the same time.
+
+For example, for LDS, the various protocol variants are provided via the
+following RPC methods:
+
+    Basic SotW: ListenerDiscoveryService.StreamListeners Incremental:
+    ListenerDiscoveryService.DeltaListeners Aggregated SotW:
+    AggregatedDiscoveryService.StreamAggregatedResources Aggregated Incremental:
+    AggregatedDiscoveryService.DeltaAggregatedResources
+
+For each of SotW and incremental, the actual communication on the stream will be
+essentially the same for both aggregated and non-aggregated, regardless of which
+of the above RPC methods you use to create the stream.
+
+For our tests, then, when a test is not variant specific, we should run the same
+test for each qualifying variant, by opening a stream with the correct RPC. For
+example, with a basic LDS test, our test runner should be able to run it against
+both ~ListenerDiscoveryService.StreamListeners~ and
+~AggregatedDisocveryService.StreamAggregatedResources~.
+
+Similarly, when we implement tests for the incremental variant, then the test
+should run against ~ListenerDiscoveryService.DeltaListeners~ and
+~AggregatedDiscoveryService.DeltaAggregatedResources~
+
+A target server may be configured for any subset of combinations from the four
+variants, and we should not lock in any required configuration for our tests.
+Instead, through something like command line flags, a person can tell the test
+runner which variants their implementation supports.
 
 ** Design Goals
-A person testing their xDS server can start up our harness with an `--ads` flag.
 
-When ADS is set, Our suite runs a hook before the tests are run to tell each step
-to assume it's working with an ADS server.
+Our test runner will have a set of flags for each of the variants. A person can use
+these flags to narrow the tests run to their server's subset of support variants.
+
+A person should only start the runner once, and then the runner executes the
+test suite against the different set variants, by running the right stream
+against each of the supported, appropriate RPC methods (as outlined above).
+
+A test may be general enough to work across all variants, or only be appropriate
+for a subset. We indicate this, in the test, using tags. The four tags, then,
+would be:
+- @sotw
+- @incremental
+- @aggregate
+- @separate
+
+If a person invokes the runner as:
+: ./runner --sotw --separate --aggregate
+
+Then the runner would go through the test suite twice. Once, running all tests
+tagged with ~@sotw~ and ~@separate~, and then running all tests flagged with
+~@sotw~ and ~@aggregate~.
+
+In addition, we set a variable in the runner for whether it is testing against
+separate or aggregate. This adjusts the RPC methods that are used throughout the
+test steps.
+
 
 Currently, we have a [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/services.go#L54][service builder]] that is passed an xDS service and then sets
 up the right kind of stream and opens the required message passing channels. We
-could use this same design to build an ADS service and follow the same behaviour.
+could use this same design to build the aggregated service. We then, ideally, do not
+need to change the steps much to have this work.
 
-We, ideally, do not need to change the steps much to have this work. We would
-mainly need to refactor the [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/steps.go#L99][clientSubscribesToService]] function, to tell it to
-open an ADS stream instead of a specific stream of the tested service. We'd also
-want to make sure our validation steps were only examining responses with the right
-type url.
-
-In addition, the suite would run tests tagged with "@ads". The easiest way to do
-this is through negation. By default the tests run as "run everything BUT ads".
-With the "@ads" flag set it becomes "run everything".
+Mainly, we would need to refactor the [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/steps.go#L99][clientSubscribesToService]] function, to
+tell it to open an ADS stream instead of a specific stream of the tested
+service. We'd also want to make sure our validation steps were only examining
+responses with the right type url.
 
 ** Process
-*** TODO Double Check assumptions and design with team
-*** Implement hook for switching between ADS and Basic
+*** Implement hook for switching between aggregated and separate
 *** Refactor functions as necessary
 *** Write ADS only test
 *** Celebrate and Dance
 ** Questions
-*** Are my assumptions about ADS and our harness correct?
-*** Should the harness detect how the target is configured?
-In this case, someone could run the harness without flags and we'd auto-detect
-how to perform our tests. This is kind of how I read it in the Statement of
-Work, but it seems the flags would be simpler and easier?

--- a/diary/ads-support.org
+++ b/diary/ads-support.org
@@ -2,7 +2,7 @@
 #+DATE: 2021-01-18
 #+AUTHOR: Zach Mandeville
 
-* Introduction
+** Introduction
 This diary is a work-in-progress, documenting how we add ADS support to the xDS
 test harness. It starts by checking assumptions I have about ADS, sets out an
 initial design for the work, and then acts as a work diary of my pgoress.
@@ -11,7 +11,7 @@ The bottom of the document has open questions for which I'd love feedback. When
 a question is answered, it'll be removed from that section and its answer woven
 into this diary.
 
-* Assumptions/Current Understanding
+** Assumptions/Current Understanding
 - The xDS transport protocol has [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol][four variants]]. An xDS server can handle any or
   all of these variants.
 - The test framework, too, should cover all variants.
@@ -25,12 +25,10 @@ into this diary.
   configured as basic or aggregated.
   + However, there will be additional 'ADS-only' tests
 - A team may want to ensure their server can handle basic /and/ ADS.
-- **The framework should be able to be configured for a server's configuration, a configuration that**
-   **holds through the entire test suite.**
-- **If a team wants to test their server with multiple configurations, they should**
-  **run the test suite multiple times, once per configuration.**
+- **The framework should be able to be configured for a server's configuration, a configuration that holds through the entire test suite.**
+- **If a team wants to test their server with multiple configurations, they should run the test suite multiple times, once per configuration.**
 
-* Design Goals
+** Design Goals
 A person testing their xDS server can start up our harness with an `--ads` flag.
 
 When ADS is set, Our suite runs a hook before the tests are run to tell each step
@@ -50,15 +48,15 @@ In addition, the suite would run tests tagged with "@ads". The easiest way to do
 this is through negation. By default the tests run as "run everything BUT ads".
 With the "@ads" flag set it becomes "run everything".
 
-* Process
-** TODO Double Check assumptions and design with team
-** Implement hook for switching between ADS and Basic
-** Refactor functions as necessary
-** Write ADS only test
-** Celebrate and Dance
-* Questions
-** Are my assumptions about ADS and our harness correct?
-** Should the harness detect how the target is configured?
+** Process
+*** TODO Double Check assumptions and design with team
+*** Implement hook for switching between ADS and Basic
+*** Refactor functions as necessary
+*** Write ADS only test
+*** Celebrate and Dance
+** Questions
+*** Are my assumptions about ADS and our harness correct?
+*** Should the harness detect how the target is configured?
 In this case, someone could run the harness without flags and we'd auto-detect
 how to perform our tests. This is kind of how I read it in the Statement of
 Work, but it seems the flags would be simpler and easier?

--- a/diary/ads-support.org
+++ b/diary/ads-support.org
@@ -3,28 +3,32 @@
 #+AUTHOR: Zach Mandeville, Mark Roth
 
 ** Introduction
-This diary is a work-in-progress, documenting how we add ADS support to the xDS
-test harness. It starts by checking assumptions I have about ADS, sets out an
-initial design for the work, and then acts as a work diary of my pgoress.
+This diary is a work-in-progress to document how we added ADS support to the xDS
+test harness. It sets up a background of the problem, our design of the work,
+and a work diary of the progress to implement it.
 
 The bottom of the document has open questions for which I'd love feedback. When
 a question is answered, it'll be removed from that section and its answer woven
 into this diary.
 
 ** Background
-The xDS transport protocol has [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol][four variants]]. Each of the variants are handled
-by [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#rpc-services-and-methods-for-each-variant][different RPC services/methods]], and so an xDS server can support any or all
-of them at the same time.
+The xDS transport protocol has [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol][four variants]]:
+- State of the World, non-aggregated
+- SOTW, aggregated
+- Incremental(or delta), non-aggregated
+- Incremental, aggregated
+
+Each of the variants are handled by [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#rpc-services-and-methods-for-each-variant][different RPC services/methods]], and an xDS
+server can support any or all of them at the same time.
 
 For example, for LDS, the various protocol variants are provided via the
 following RPC methods:
+- SotW, non aggregated: ListenerDiscoveryService.StreamListeners
+- SOTW, Aggregated : AggregatedDiscoveryService.StreamAggregatedResources
+- Incremental, non-agg: ListenerDiscoveryService.DeltaListeners
+- Incremental, Aggregated: AggregatedDiscoveryService.DeltaAggregatedResources
 
-    Basic SotW: ListenerDiscoveryService.StreamListeners Incremental:
-    ListenerDiscoveryService.DeltaListeners Aggregated SotW:
-    AggregatedDiscoveryService.StreamAggregatedResources Aggregated Incremental:
-    AggregatedDiscoveryService.DeltaAggregatedResources
-
-For each of SotW and incremental, the actual communication on the stream will be
+For  SotW and incremental, the actual communication on the stream will be
 essentially the same for both aggregated and non-aggregated, regardless of which
 of the above RPC methods you use to create the stream.
 
@@ -34,57 +38,100 @@ example, with a basic LDS test, our test runner should be able to run it against
 both ~ListenerDiscoveryService.StreamListeners~ and
 ~AggregatedDisocveryService.StreamAggregatedResources~.
 
-Similarly, when we implement tests for the incremental variant, then the test
-should run against ~ListenerDiscoveryService.DeltaListeners~ and
-~AggregatedDiscoveryService.DeltaAggregatedResources~
-
 A target server may be configured for any subset of combinations from the four
 variants, and we should not lock in any required configuration for our tests.
 Instead, through something like command line flags, a person can tell the test
 runner which variants their implementation supports.
-
-** Design Goals
-
-Our test runner will have a set of flags for each of the variants. A person can use
-these flags to narrow the tests run to their server's subset of support variants.
-
+** Design
+*** Specifying variants with cli flags
 A person should only start the runner once, and then the runner executes the
 test suite against the different set variants, by running the right stream
 against each of the supported, appropriate RPC methods (as outlined above).
 
-A test may be general enough to work across all variants, or only be appropriate
-for a subset. We indicate this, in the test, using tags. The four tags, then,
-would be:
+A person can indicate which variants their target supports using the flag
+~--variants~. This flag expects a four character stirng made up of 1's and 0's.
+1 represents support, 0 non-support. The variants are, right to left, sotw
+non-agg, sotw agg, incremental non-agg, incremental agg.
+
+So if a person wanted to run the test suite against a server
+running only non-aggregated, but supporting sotw and incremental, they'd run:
+: ./runner --variants 1010
+
+If they are an edge case that only supports SoTW, non-aggregated and
+incremental, aggregated, then they'd run:
+: ./runner --variants 1001
+*** Tagging  the tests
+For the tests themselves, some may be general enough to work across all
+variants, and some may only be appropriate for a particular combination. We can
+indicate this using tags added to the top of the test scenario. The tags are:
 - @sotw
 - @incremental
 - @aggregate
 - @separate
+*** reading flags and tags in our main
+In our main function, we parse the variant flag to build an array of boolean values.
+For each true value in the array, we run the test suite for that variant. This means
+the suite can run from 1-4 times.
 
-If a person invokes the runner as:
-: ./runner --sotw --separate --aggregate
+(The ~aggregate~ and ~incremental~ variables are passed into the runner on suite
+initialization, so that all the test step functions can adjust, as necessary,
+for the variant.)
 
-Then the runner would go through the test suite twice. Once, running all tests
-tagged with ~@sotw~ and ~@separate~, and then running all tests flagged with
-~@sotw~ and ~@aggregate~.
+*** Changes to our test Steps
 
-In addition, we set a variable in the runner for whether it is testing against
-separate or aggregate. This adjusts the RPC methods that are used throughout the
-test steps.
+The main flow for our tests is to set up state on the target server using the
+adapter, then initialize a service for the duration of the test. This service
+includes channels for requests and responses (and caches for both). Each test
+step in the scenario can use this service interface to pass along new requests
+or update state as nceeded.
 
+We can use the same pattern for ADS, with some modifications:
 
-Currently, we have a [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/services.go#L54][service builder]] that is passed an xDS service and then sets
-up the right kind of stream and opens the required message passing channels. We
-could use this same design to build the aggregated service. We then, ideally, do not
-need to change the steps much to have this work.
+Originally, the service interface included its typeURL value.
+When we needed to make a new request, we'd use the service's assign typeURL.
+This doesn't work for ADs, so now our new request functions pass the required
+typeURL, which is determined from the test step itself.
 
-Mainly, we would need to refactor the [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/steps.go#L99][clientSubscribesToService]] function, to
-tell it to open an ADS stream instead of a specific stream of the tested
-service. We'd also want to make sure our validation steps were only examining
-responses with the right type url.
+Originally, our subscribing step assumed you would be doing one subscription per
+scenario, and so built a service interface as part of the subscription step.
+This doesn't work for ADS-Only tests where you are subscribing to multiple
+services across the same stream, and building a new service interface means
+clearing the existing caches. Now, the subscribing function checks if we
+already have a service initialized and, if so, uses its existing inferface. I
+think this change makes the function stronge overall, and may help me fix the
+unsubscribing issues.
 
+*** Uncertain changes
+I added a new step at the end of our ADS-only test, that reads:
+"And the server does not respond more than necessary".
+
+This step is functionally identical to our current step "And the client ACKS to
+which the server does not respond".
+
+I duplicated the function due to an issue in the function's logic. It closes
+down our response and request channels, so that any remaining messages can come
+through and we can look at the entire range of messages sent. Then, we count
+the # of responses and # of requests. Since ACK'ing is built into the client's
+lifecycle, and it is acking every response it gets from the server, than in this
+final step there should be 1 more request than response. If not, the step fails.
+
+This logic requires the step to be run at the end of the test. However, in the
+test cases doc, for the ADS-only test there are multiple "and the client sends
+an ack to which the server doesn't respond". If I tried to match the test case
+verbatim, we'd be closing the ADS stream too early. If I just put the existing
+step at the end, it seems as if we are only ACK'ing once.
+
+Now, the ACK'ing is assumed to happen as part of the test, and we just check at
+the end that the server hasn't sent more responses than it needed to. I worry
+this makes the test steps too opaque, and it may be highlighting that the
+existing steps are not as elegant as they could be. I am v. open for feedback or
+suggestions on if this needs to change, and how it could be improved.
 ** Process
-*** Implement hook for switching between aggregated and separate
-*** Refactor functions as necessary
-*** Write ADS only test
-*** Celebrate and Dance
+*** DONE Implement hook for switching between variants
+*** DONE Refactor functions as necessary
+*** DONE Write ADS only test
+*** TODO Celebrate and Dance
 ** Questions
+- Does the wording of the ADS test work for everyone?
+  + does the test run as we'd expect?
+- Are there any objections/improvements to the --variants flag?

--- a/diary/ads-support.org
+++ b/diary/ads-support.org
@@ -63,24 +63,20 @@ incremental, aggregated, then they'd run:
 *** Tagging  the tests
 For the tests themselves, some may be general enough to work across all
 variants, and some may only be appropriate for a particular combination. We can
-indicate this using tags added to the top of the test scenario. The tags are:
+indicate this using [[https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L8][tags added to the top of the test scenario]]. The tags are:
 - @sotw
 - @incremental
 - @aggregate
 - @separate
 *** reading flags and tags in our main
-In our main function, we parse the variant flag to build an array of boolean values.
-For each true value in the array, we run the test suite for that variant. This means
+In our main function, we [[https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L101][parse the variant flag]] to build an array of boolean values.
+For each true value in the array, we [[https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L152][run the test suite]] for that variant. This means
 the suite can run from 1-4 times.
-
-(The ~aggregate~ and ~incremental~ variables are passed into the runner on suite
-initialization, so that all the test step functions can adjust, as necessary,
-for the variant.)
 
 *** Changes to our test Steps
 
 The main flow for our tests is to set up state on the target server using the
-adapter, then initialize a service for the duration of the test. This service
+adapter, then [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/services.go#L39][initialize a service]] for the duration of the test. This service
 includes channels for requests and responses (and caches for both). Each test
 step in the scenario can use this service interface to pass along new requests
 or update state as nceeded.
@@ -89,24 +85,24 @@ We can use the same pattern for ADS, with some modifications:
 
 Originally, the service interface included its typeURL value.
 When we needed to make a new request, we'd use the service's assign typeURL.
-This doesn't work for ADs, so now our new request functions pass the required
-typeURL, which is determined from the test step itself.
+This doesn't work for ADs, so now [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L102][our new request functions pass the required
+typeURL]], which is determined from the test step itself.
 
 Originally, our subscribing step assumed you would be doing one subscription per
 scenario, and so built a service interface as part of the subscription step.
 This doesn't work for ADS-Only tests where you are subscribing to multiple
 services across the same stream, and building a new service interface means
-clearing the existing caches. Now, the subscribing function checks if we
-already have a service initialized and, if so, uses its existing inferface. I
-think this change makes the function stronge overall, and may help me fix the
+clearing the existing caches. Now, the subscribing function [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L107][checks if we
+already]] have a service initialized and, if so, uses its existing inferface. I
+think this change makes the function stronger overall, and may help me fix the
 unsubscribing issues.
 
 *** Uncertain changes
 I added a new step at the end of our ADS-only test, that reads:
-"And the server does not respond more than necessary".
+[[https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L192]["And the server never responds more than necessary"]].
 
-This step is functionally identical to our current step "And the client ACKS to
-which the server does not respond".
+This step is functionally identical to our current step [[https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L257]["And the client ACKS to
+which the server does not respond".]]
 
 I duplicated the function due to an issue in the function's logic. It closes
 down our response and request channels, so that any remaining messages can come

--- a/diary/ads-support.org
+++ b/diary/ads-support.org
@@ -1,0 +1,64 @@
+#+TITLE: Ads Support
+#+DATE: 2021-01-18
+#+AUTHOR: Zach Mandeville
+
+* Introduction
+This diary is a work-in-progress, documenting how we add ADS support to the xDS
+test harness. It starts by checking assumptions I have about ADS, sets out an
+initial design for the work, and then acts as a work diary of my pgoress.
+
+The bottom of the document has open questions for which I'd love feedback. When
+a question is answered, it'll be removed from that section and its answer woven
+into this diary.
+
+* Assumptions/Current Understanding
+- The xDS transport protocol has [[https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol][four variants]]. An xDS server can handle any or
+  all of these variants.
+- The test framework, too, should cover all variants.
+  + It [[https://github.com/ii/xds-test-harness/tree/de750b5ba26ba3f0de5a6ecca1fcac20b787ee30][currently]] only supports SoTW(State of the World)/Basic
+  + SoTW/ADS(Aggregated Discovery) should be the added next, followed by Delta/Basic and Delta/ADS.
+- An xDS server is configured for a single variant on startup
+  + e.g: if it's set to SoTW/ADS, then all CDS,LDS,RDS,EDS features will be handled
+    via ADS
+  + It cannot switch itself from basic to ADS and remain running.
+- The intent of our current tests are the same, no matter if a server is
+  configured as basic or aggregated.
+  + However, there will be additional 'ADS-only' tests
+- A team may want to ensure their server can handle basic /and/ ADS.
+- **The framework should be able to be configured for a server's configuration, a configuration that**
+   **holds through the entire test suite.**
+- **If a team wants to test their server with multiple configurations, they should**
+  **run the test suite multiple times, once per configuration.**
+
+* Design Goals
+A person testing their xDS server can start up our harness with an `--ads` flag.
+
+When ADS is set, Our suite runs a hook before the tests are run to tell each step
+to assume it's working with an ADS server.
+
+Currently, we have a [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/services.go#L54][service builder]] that is passed an xDS service and then sets
+up the right kind of stream and opens the required message passing channels. We
+could use this same design to build an ADS service and follow the same behaviour.
+
+We, ideally, do not need to change the steps much to have this work. We would
+mainly need to refactor the [[https://github.com/ii/xds-test-harness/blob/ads-support/internal/runner/steps.go#L99][clientSubscribesToService]] function, to tell it to
+open an ADS stream instead of a specific stream of the tested service. We'd also
+want to make sure our validation steps were only examining responses with the right
+type url.
+
+In addition, the suite would run tests tagged with "@ads". The easiest way to do
+this is through negation. By default the tests run as "run everything BUT ads".
+With the "@ads" flag set it becomes "run everything".
+
+* Process
+** TODO Double Check assumptions and design with team
+** Implement hook for switching between ADS and Basic
+** Refactor functions as necessary
+** Write ADS only test
+** Celebrate and Dance
+* Questions
+** Are my assumptions about ADS and our harness correct?
+** Should the harness detect how the target is configured?
+In this case, someone could run the harness without flags and we'd auto-detect
+how to perform our tests. This is kind of how I read it in the Statement of
+Work, but it seems the flags would be simpler and easier?

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -1,11 +1,9 @@
-
 Feature: Fetching Resources with LDS and CDS
   Client can do wildcard subscriptions or normal subscriptions
   and receive updates when any subscribed resources change.
 
   These features come from this list of test cases:
   https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
-
 
   @sotw @separate @aggregated
   Scenario Outline: The service should send all resources on a wildcard request.
@@ -179,3 +177,21 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
       | "RDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
       | "EDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
+
+
+    @sotw @aggregated @active
+    Scenario: Client can subscribe to multiple services via ADS
+      Given a target setup with <service>, <resources>, and <starting version>
+      When the Client subscribes to a <subset of resources> for <service>
+      Then the Client receives the <subset of resources> for <service> and <starting version>
+      When the Client then subscribes to a <subset of resources> for <other service>
+      Then the Client receives the <subset of resources> for <other service> and <starting version>
+      When a <subset of resources> of the <service> is updated to the <next version>
+      Then the Client receives the <subset of resources> for <service> and <next version>
+      # trying out different language for server not responding to acks
+      And the service never responds more than necessary
+
+      Examples:
+        | service | other service | starting version | resources | subset of resources | next version |
+        | "CDS"   | "LDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |
+        | "EDS"   | "RDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -7,7 +7,7 @@ Feature: Fetching Resources with LDS and CDS
   https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
 
 
-
+  @sotw @separate @aggregated
   Scenario Outline: The service should send all resources on a wildcard request.
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -5,7 +5,7 @@ Feature: Fetching Resources with LDS and CDS
   These features come from this list of test cases:
   https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
 
-  @sotw @separate @aggregated
+  @sotw @separate @aggregated @active
   Scenario Outline: The service should send all resources on a wildcard request.
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -184,7 +184,7 @@ Feature: Fetching Resources with LDS and CDS
       Given a target setup with <service>, <resources>, and <starting version>
       When the Client subscribes to a <subset of resources> for <service>
       Then the Client receives the <subset of resources> and <starting version> for <service>
-      When the Client then subscribes to a <subset of resources> for <other service>
+      When the Client subscribes to a <subset of resources> for <other service>
       Then the Client receives the <subset of resources> and <starting version> for <other service>
       When a <subset of resources> of the <service> is updated to the <next version>
       Then the Client receives the <subset of resources> and <next version> for <service>

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -179,7 +179,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
 
 
-    @sotw @aggregated @active
+    @sotw @aggregated
     Scenario: Client can subscribe to multiple services via ADS
       Given a target setup with <service>, <resources>, and <starting version>
       When the Client subscribes to a <subset of resources> for <service>

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -5,7 +5,7 @@ Feature: Fetching Resources with LDS and CDS
   These features come from this list of test cases:
   https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
 
-  @sotw @separate @aggregated @active
+  @sotw @non-aggregated @aggregated @active
   Scenario Outline: The service should send all resources on a wildcard request.
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -18,7 +18,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "F,D,E"            |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario Outline: The service should send updates to the client
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -33,7 +33,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario Outline: Wildcard subscriptions receive updates when new resources are added
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -48,7 +48,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "G"          | "D,E,F,G"          | "2"          |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario:  When subscribing to specific resources, receive only these resources
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -63,7 +63,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B"     | "A,B"               |
 
 
-  @CDS @LDS @sotw @separate @aggregated
+  @CDS @LDS @sotw @non-aggregated @aggregated
   Scenario: When subscribing to specific resources, receive response when those resources change
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -78,7 +78,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "L,G"               | "G"                 | "2"          |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario: When subscribing to specific resources, receive response when those resources change
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -93,7 +93,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B,C,D"   | "B,D"               | "B"                 | "2"          |
 
 
-  @CDS @LDS @sotw @separate @aggregated
+  @CDS @LDS @sotw @non-aggregated @aggregated
   Scenario: When subscribing to resources that don't exist, receive response when they are created
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -108,7 +108,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "B,D,X"             | "B,D"           | "X"             | "2"          |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario: When subscribing to resources that don't exist, receive response when they are created
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -123,7 +123,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B,C,D"   | "A,Z"               | "A"             | "Z"             | "2"          |
 
 
-  @CDS @LDS @sotw @separate @aggregated
+  @CDS @LDS @sotw @non-aggregated @aggregated
   Scenario: Client can unsubcribe from some resources
     # This test does not check if the final results are only the subscribed resources
     # it is valid(though not desired) for a server to send more than is requested.
@@ -142,7 +142,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario: Client can unsubcribe from some resources
     # difference from test above is use of the word ONLY in the final THEN step
     # This currently does not pass for go-control-plane
@@ -160,7 +160,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
 
 
-  @sotw @separate @aggregated
+  @sotw @non-aggregated @aggregated
   Scenario: Client can unsubscribe from all resources
     # This is not working currently, the unsusbcribe is not registered,
     # neither as an unsubscribe nor a new wildcard request

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -20,7 +20,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "F,D,E"            |
 
 
-
+  @sotw @separate @aggregated
   Scenario Outline: The service should send updates to the client
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -35,7 +35,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "2"          | "D,E,F"   | "D,E,F"            | "D"             |
 
 
-
+  @sotw @separate @aggregated
   Scenario Outline: Wildcard subscriptions receive updates when new resources are added
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -50,7 +50,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "D,E,F"   | "G"          | "D,E,F,G"          | "2"          |
 
 
-
+  @sotw @separate @aggregated
   Scenario:  When subscribing to specific resources, receive only these resources
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -65,7 +65,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B"     | "A,B"               |
 
 
-  @CDS @LDS
+  @CDS @LDS @sotw @separate @aggregated
   Scenario: When subscribing to specific resources, receive response when those resources change
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -80,7 +80,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "L,G"               | "G"                 | "2"          |
 
 
-
+  @sotw @separate @aggregated
   Scenario: When subscribing to specific resources, receive response when those resources change
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -95,7 +95,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B,C,D"   | "B,D"               | "B"                 | "2"          |
 
 
-  @CDS @LDS
+  @CDS @LDS @sotw @separate @aggregated
   Scenario: When subscribing to resources that don't exist, receive response when they are created
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -110,7 +110,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "B,D,X"             | "B,D"           | "X"             | "2"          |
 
 
-
+  @sotw @separate @aggregated
   Scenario: When subscribing to resources that don't exist, receive response when they are created
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client subscribes to a <subset of resources> for <service>
@@ -125,7 +125,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "A,B,C,D"   | "A,Z"               | "A"             | "Z"             | "2"          |
 
 
-  @CDS @LDS
+  @CDS @LDS @sotw @separate @aggregated
   Scenario: Client can unsubcribe from some resources
     # This test does not check if the final results are only the subscribed resources
     # it is valid(though not desired) for a server to send more than is requested.
@@ -144,7 +144,7 @@ Feature: Fetching Resources with LDS and CDS
       | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
 
 
-
+  @sotw @separate @aggregated
   Scenario: Client can unsubcribe from some resources
     # difference from test above is use of the word ONLY in the final THEN step
     # This currently does not pass for go-control-plane
@@ -162,7 +162,7 @@ Feature: Fetching Resources with LDS and CDS
       | "EDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
 
 
-
+  @sotw @separate @aggregated
   Scenario: Client can unsubscribe from all resources
     # This is not working currently, the unsusbcribe is not registered,
     # neither as an unsubscribe nor a new wildcard request

--- a/features/subscriptions.feature
+++ b/features/subscriptions.feature
@@ -183,15 +183,15 @@ Feature: Fetching Resources with LDS and CDS
     Scenario: Client can subscribe to multiple services via ADS
       Given a target setup with <service>, <resources>, and <starting version>
       When the Client subscribes to a <subset of resources> for <service>
-      Then the Client receives the <subset of resources> for <service> and <starting version>
+      Then the Client receives the <subset of resources> and <starting version> for <service>
       When the Client then subscribes to a <subset of resources> for <other service>
-      Then the Client receives the <subset of resources> for <other service> and <starting version>
+      Then the Client receives the <subset of resources> and <starting version> for <other service>
       When a <subset of resources> of the <service> is updated to the <next version>
-      Then the Client receives the <subset of resources> for <service> and <next version>
+      Then the Client receives the <subset of resources> and <next version> for <service>
       # trying out different language for server not responding to acks
       And the service never responds more than necessary
 
       Examples:
         | service | other service | starting version | resources | subset of resources | next version |
         | "CDS"   | "LDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |
-        | "EDS"   | "RDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |
+        | "RDS"   | "EDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -129,6 +129,7 @@ func ParseDiscoveryResponse(res *envoy_service_discovery_v3.DiscoveryResponse) (
 	simpRes.Version = res.VersionInfo
 	simpRes.Nonce = res.Nonce
 	simpRes.Resources = []string{}
+	simpRes.TypeUrl = res.TypeUrl
 	switch res.TypeUrl {
 	case TypeUrlLDS:
 		for _, resource := range res.GetResources() {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -64,4 +64,5 @@ type SimpleResponse struct {
 	Version   string
 	Resources []string
 	Nonce     string
+	TypeUrl   string
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -39,6 +39,7 @@ type Runner struct {
 	Target  *ClientConfig
 	NodeID  string
 	Cache   *Cache
+	Aggregated bool
 	Service *XDSService
 }
 
@@ -47,12 +48,14 @@ func FreshRunner(current ...*Runner) *Runner {
 		adapter = &ClientConfig{}
 		target  = &ClientConfig{}
 		nodeID  = ""
+		aggregated = false
 	)
 
 	if len(current) > 0 {
 		adapter = current[0].Adapter
 		target = current[0].Target
 		nodeID = current[0].NodeID
+		aggregated = current[0].Aggregated
 
 	}
 
@@ -62,19 +65,20 @@ func FreshRunner(current ...*Runner) *Runner {
 		NodeID:  nodeID,
 		Cache:   &Cache{},
 		Service: &XDSService{},
+		Aggregated: aggregated,
 	}
 }
 
-func connectViaGRPC(client *ClientConfig, server string) (conn *grpc.ClientConn, err error) {
-	conn, err = grpc.Dial(client.Port, opts...)
-	if err != nil {
-		err = fmt.Errorf("Cannot connect at %v: %v\n", client.Port, err)
-		return nil, err
+	func connectViaGRPC(client *ClientConfig, server string) (conn *grpc.ClientConn, err error) {
+		conn, err = grpc.Dial(client.Port, opts...)
+		if err != nil {
+			err = fmt.Errorf("Cannot connect at %v: %v\n", client.Port, err)
+			return nil, err
+		}
+		log.Debug().
+			Msgf("Runner connected to %v", server)
+		return conn, nil
 	}
-	log.Debug().
-		Msgf("Runner connected to %v", server)
-	return conn, nil
-}
 
 func (r *Runner) ConnectClient(server, address string) error {
 	var client *ClientConfig

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -167,12 +167,12 @@ func (r *Runner) Stream(service *XDSService) error {
 			in, err := service.Stream.Recv()
 			if err == io.EOF {
 				log.Debug().
-					Msg("No more Discovery Responses from LDS stream")
+					Msgf("No more Discovery Responses from %v stream", r.Service.Name)
 				close(service.Channels.Res)
 				return
 			}
 			if err != nil {
-				log.Err(err).Msg("error receiving responses on LDS stream")
+				log.Err(err).Msgf("error receiving responses on %v stream", r.Service.Name)
 				service.Channels.Err <- err
 				return
 			}

--- a/internal/runner/services.go
+++ b/internal/runner/services.go
@@ -3,11 +3,13 @@ package runner
 import (
 	"context"
 	"time"
+
 	cds "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	eds "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	lds "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	rds "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
-	eds "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 )
 
@@ -320,7 +322,7 @@ func getBuilder(builderType string) serviceBuilder {
 	case "EDS":
 		return &EDSBuilder{}
 	case "ADS":
-		return &EDSBuilder{}
+		return &ADSBuilder{}
 	default:
 		return nil
 	}

--- a/internal/runner/services.go
+++ b/internal/runner/services.go
@@ -9,15 +9,7 @@ import (
 	eds "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	lds "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	rds "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
-)
-
-const (
-	TypeUrlLDS = "type.googleapis.com/envoy.config.listener.v3.Listener"
-	TypeUrlCDS = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
-	TypeUrlRDS = "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
-	TypeUrlEDS = "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"
 )
 
 type Channels struct {
@@ -46,7 +38,6 @@ type Stream interface {
 
 type XDSService struct {
 	Name     string
-	TypeURL  string
 	Channels *Channels
 	Cache    *ServiceCache
 	Stream   Stream
@@ -62,26 +53,10 @@ type serviceBuilder interface {
 
 type LDSBuilder struct {
 	Name     string
-	TypeURL  string
 	Channels *Channels
 	Cache    *ServiceCache
 	Stream   Stream
 	Context  Context
-}
-
-func getTypeUrl(service string) (typeUrl string) {
-	typeUrl = ""
-	switch service {
-	case "LDS":
-		typeUrl = TypeUrlLDS
-	case "CDS":
-		typeUrl = TypeUrlCDS
-	case "EDS":
-		typeUrl = TypeUrlEDS
-	case "RDS":
-		typeUrl = TypeUrlRDS
-	}
-	return typeUrl
 }
 
 func (b *LDSBuilder) openChannels() {
@@ -115,7 +90,6 @@ func (b *LDSBuilder) setInitResources(res []string) {
 func (b *LDSBuilder) getService(srv string) *XDSService {
 	return &XDSService{
 		Name:     "LDS",
-		TypeURL:  getTypeUrl(srv),
 		Channels: b.Channels,
 		Cache:    b.Cache,
 		Stream:   b.Stream,
@@ -124,7 +98,6 @@ func (b *LDSBuilder) getService(srv string) *XDSService {
 
 type CDSBuilder struct {
 	Name     string
-	TypeURL  string
 	Channels *Channels
 	Cache    *ServiceCache
 	Stream   Stream
@@ -162,7 +135,6 @@ func (b *CDSBuilder) setInitResources(res []string) {
 func (b *CDSBuilder) getService(srv string) *XDSService {
 	return &XDSService{
 		Name:     "CDS",
-		TypeURL:  getTypeUrl(srv),
 		Channels: b.Channels,
 		Cache:    b.Cache,
 		Stream:   b.Stream,
@@ -171,7 +143,6 @@ func (b *CDSBuilder) getService(srv string) *XDSService {
 
 type RDSBuilder struct {
 	Name     string
-	TypeURL  string
 	Channels *Channels
 	Cache    *ServiceCache
 	Stream   Stream
@@ -209,7 +180,6 @@ func (b *RDSBuilder) setInitResources(res []string) {
 func (b *RDSBuilder) getService(srv string) *XDSService {
 	return &XDSService{
 		Name:     "RDS",
-		TypeURL:  getTypeUrl(srv),
 		Channels: b.Channels,
 		Cache:    b.Cache,
 		Stream:   b.Stream,
@@ -218,7 +188,6 @@ func (b *RDSBuilder) getService(srv string) *XDSService {
 
 type EDSBuilder struct {
 	Name     string
-	TypeURL  string
 	Channels *Channels
 	Cache    *ServiceCache
 	Stream   Stream
@@ -256,7 +225,6 @@ func (b *EDSBuilder) setInitResources(res []string) {
 func (b *EDSBuilder) getService(srv string) *XDSService {
 	return &XDSService{
 		Name:     "EDS",
-		TypeURL:  getTypeUrl(srv),
 		Channels: b.Channels,
 		Cache:    b.Cache,
 		Stream:   b.Stream,
@@ -265,7 +233,6 @@ func (b *EDSBuilder) getService(srv string) *XDSService {
 
 type ADSBuilder struct {
 	Name     string
-	TypeURL  string
 	Channels *Channels
 	Cache    *ServiceCache
 	Stream   Stream
@@ -303,7 +270,6 @@ func (b *ADSBuilder) setInitResources(res []string) {
 func (b *ADSBuilder) getService(service string) *XDSService {
 	return &XDSService{
 		Name:     "ADS",
-		TypeURL:  getTypeUrl(service),
 		Channels: b.Channels,
 		Cache:    b.Cache,
 		Stream:   b.Stream,

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -85,6 +85,7 @@ func (r *Runner) ATargetSetupWithServiceResourcesAndVersion(service, resources, 
 }
 
 func (r *Runner) TheClientDoesAWildcardSubscriptionToService(service string) error {
+	log.Info().Msgf("The Runner is aggregated: %v", r.Aggregated)
 	resources := []string{}
 	r.ClientSubscribesToServiceForResources(service, resources)
 	return nil
@@ -97,14 +98,19 @@ func (r *Runner) ClientSubscribesToASubsetOfResourcesForService(subset, service 
 }
 
 func (r *Runner) ClientSubscribesToServiceForResources(srv string, resources []string) error {
-	builder := getBuilder(srv)
+	var builder serviceBuilder
+	if r.Aggregated {
+		builder = getBuilder("ADS")
+	} else {
+	  builder = getBuilder(srv)
+	}
 	builder.openChannels()
 	builder.setInitResources(resources)
 	err := builder.setStream(r.Target.Conn)
 	if err != nil {
 		return err
 	}
-	r.Service = builder.getService()
+	r.Service = builder.getService(srv)
 
 	request := r.NewRequest(r.Service.Cache.InitResource, r.Service.TypeURL)
 

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -254,23 +254,6 @@ func (r *Runner) theClientReceivesOnlyTheCorrectResourceAndVersion(resource, ver
 	}
 }
 
-func (r *Runner) TheClientSendsAnACKToWhichTheDoesNotRespond(service string) error {
-	stream := r.Service
-	stream.Channels.Done <- true
-
-	// give some time for the final messages to come through, if there's any lingering responses.
-	time.Sleep(3 * time.Second)
-	log.Debug().
-		Msgf("Request Count: %v Response Count: %v", len(stream.Cache.Requests), len(stream.Cache.Responses))
-	if len(stream.Cache.Requests) <= len(stream.Cache.Responses) {
-		err := errors.New("There are more responses than requests.  This indicates the server responded to the last ack")
-		log.Err(err).
-			Msgf("Requests:%v, Responses: \v", stream.Cache.Requests, stream.Cache.Responses)
-		return err
-	}
-	return nil
-}
-
 func (r *Runner) TheServiceNeverRespondsMoreThanNecessary() error {
 	stream := r.Service
 	stream.Channels.Done <- true
@@ -480,7 +463,7 @@ func (r *Runner) LoadSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the Client receives the "([^"]*)" and "([^"]*)"$`, r.TheClientReceivesCorrectResourcesAndVersion)
 	ctx.Step(`^the Client receives only the "([^"]*)" and "([^"]*)"$`, r.theClientReceivesOnlyTheCorrectResourceAndVersion)
 	ctx.Step(`^the Client does not receive any message from "([^"]*)"$`, r.ClientDoesNotReceiveAnyMessageFromService)
-	ctx.Step(`^the Client sends an ACK to which the "([^"]*)" does not respond$`, r.TheClientSendsAnACKToWhichTheDoesNotRespond)
+	ctx.Step(`^the Client sends an ACK to which the "([^"]*)" does not respond$`, r.TheServiceNeverRespondsMoreThanNecessary)
 	ctx.Step(`^a "([^"]*)" of the "([^"]*)" is updated to the "([^"]*)"$`, r.ResourceOfTheServiceIsUpdatedToNextVersion)
 	ctx.Step(`^a "([^"]*)" is added to the "([^"]*)" with "([^"]*)"$`, r.ResourceIsAddedToServiceWithVersion)
 	ctx.Step(`^the Client updates subscription to a "([^"]*)" of "([^"]*)" with "([^"]*)"$`, r.ClientUpdatesSubscriptionToAResourceForServiceWithVersion)

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 	if supportedVariants[0] {
 		incremental = false
 		aggregated = false
-		godogOpts.Tags = "@sotw && @separate"
+		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@sotw","@separate"}, " && ")
 		suite.Run();
 	}
 
@@ -150,7 +150,7 @@ func main() {
 	if supportedVariants[1] {
 		incremental = false
 		aggregated = true
-		godogOpts.Tags = "@sotw && @aggregated"
+		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@sotw","@aggregated"}, " && ")
 		suite.Run();
 	}
 
@@ -158,7 +158,7 @@ func main() {
 	if supportedVariants[2] {
 		incremental = true
 		aggregated = false
-		godogOpts.Tags = "@incremental && @separate"
+		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@incremental","@separate"}, " && ")
 		suite.Run();
 	}
 
@@ -166,7 +166,7 @@ func main() {
 	if supportedVariants[3] {
 		incremental = true
 		aggregated = true
-		godogOpts.Tags = "@incremental && @aggregated"
+		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@incremental","@aggregated"}, " && ")
 		suite.Run();
 	}
 	os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -117,6 +117,14 @@ func supportedVariants(combo string) (err error, supportedVariants []bool) {
 	return nil, supportedVariants
 }
 
+func combineTags(godogTags string, customTags []string) (tags string){
+	if godogTags != "" {
+		customTags = append(customTags, godogTags)
+	}
+	tags = strings.Join(customTags, " && ")
+	return tags
+}
+
 func main() {
 	pflag.Parse()
 	godogOpts.Paths = pflag.Args()
@@ -131,6 +139,8 @@ func main() {
 		Options:              &godogOpts,
 	}
 
+	// any tags passed in with -t when invoking the runner
+	godogTags := godogOpts.Tags
 	// we have four variants, either set to T or F
 	err, supportedVariants := supportedVariants(*variants)
 	if err != nil {
@@ -142,7 +152,8 @@ func main() {
 	if supportedVariants[0] {
 		incremental = false
 		aggregated = false
-		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@sotw","@separate"}, " && ")
+		customTags := []string{"@sotw", "@separate"}
+		godogOpts.Tags = combineTags(godogTags, customTags)
 		suite.Run();
 	}
 
@@ -150,7 +161,8 @@ func main() {
 	if supportedVariants[1] {
 		incremental = false
 		aggregated = true
-		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@sotw","@aggregated"}, " && ")
+		customTags := []string{"@sotw", "@aggregated"}
+		godogOpts.Tags = combineTags(godogTags, customTags)
 		suite.Run();
 	}
 
@@ -158,7 +170,8 @@ func main() {
 	if supportedVariants[2] {
 		incremental = true
 		aggregated = false
-		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@incremental","@separate"}, " && ")
+		customTags := []string{"@incremental", "@separate"}
+		godogOpts.Tags = combineTags(godogTags, customTags)
 		suite.Run();
 	}
 
@@ -166,7 +179,8 @@ func main() {
 	if supportedVariants[3] {
 		incremental = true
 		aggregated = true
-		godogOpts.Tags = strings.Join([]string{godogOpts.Tags, "@incremental","@aggregated"}, " && ")
+		customTags := []string{"@incremental", "@aggregated"}
+		godogOpts.Tags = combineTags(godogTags, customTags)
 		suite.Run();
 	}
 	os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-
 	"strings"
 
 	"github.com/cucumber/godog"
@@ -20,7 +19,7 @@ var (
 	adapterAddress = pflag.StringP("adapter", "A", ":17000", "port of adapter on target")
 	targetAddress  = pflag.StringP("target", "T", ":18000", "port of xds target to test")
 	nodeID         = pflag.StringP("nodeID", "N", "test-id", "node id of target")
-	variant       = pflag.StringArrayP("variant", "V", []string{"sotw non-aggregated", "sotw aggregated","incremental non-aggregated", "incremental aggregated"}, "xDS protocol variant your server supports. Add a separate flag per each supported variant.\n Possibleariants are: sotw non-aggregated\n, sotw aggregated\n, incremental non-aggregated\n, incremental aggregated\n.")
+	variant        = pflag.StringArrayP("variant", "V", []string{"sotw non-aggregated", "sotw aggregated", "incremental non-aggregated", "incremental aggregated"}, "xDS protocol variant your server supports. Add a separate flag per each supported variant.\n Possibleariants are: sotw non-aggregated\n, sotw aggregated\n, incremental non-aggregated\n, incremental aggregated\n.")
 	aggregated     = false
 	incremental    = false
 
@@ -116,7 +115,7 @@ func supportedVariants(variants []string) (err error, supported map[string]bool)
 	return nil, supported
 }
 
-func combineTags(godogTags string, customTags []string) (tags string){
+func combineTags(godogTags string, customTags []string) (tags string) {
 	if godogTags != "" {
 		customTags = append(customTags, godogTags)
 	}
@@ -138,7 +137,6 @@ func main() {
 		Options:              &godogOpts,
 	}
 
-
 	// any tags passed in with -t when invoking the runner
 	godogTags := godogOpts.Tags
 	err, supportedVariants := supportedVariants(*variant)
@@ -150,9 +148,9 @@ func main() {
 	if supportedVariants["sotw non-aggregated"] {
 		incremental = false
 		aggregated = false
-		customTags := []string{"@sotw", "@separate"}
+		customTags := []string{"@sotw", "@non-aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
-		suite.Run();
+		suite.Run()
 	}
 
 	if supportedVariants["sotw aggregated"] {
@@ -160,15 +158,15 @@ func main() {
 		aggregated = true
 		customTags := []string{"@sotw", "@aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
-		suite.Run();
+		suite.Run()
 	}
 
 	if supportedVariants["incremental non-aggregated"] {
 		incremental = true
 		aggregated = false
-		customTags := []string{"@incremental", "@separate"}
+		customTags := []string{"@incremental", "@non-aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
-		suite.Run();
+		suite.Run()
 	}
 
 	if supportedVariants["incremental aggregated"] {
@@ -176,7 +174,7 @@ func main() {
 		aggregated = true
 		customTags := []string{"@incremental", "@aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
-		suite.Run();
+		suite.Run()
 	}
 	os.Exit(0)
 }

--- a/main.go
+++ b/main.go
@@ -143,9 +143,7 @@ func main() {
 		incremental = false
 		aggregated = false
 		godogOpts.Tags = "@sotw && @separate"
-		if status := suite.Run(); status == 1 {
-			os.Exit(status)
-		}
+		suite.Run();
 	}
 
 	//SOTW, Aggregated
@@ -153,9 +151,7 @@ func main() {
 		incremental = false
 		aggregated = true
 		godogOpts.Tags = "@sotw && @aggregated"
-		if status := suite.Run(); status == 1 {
-			os.Exit(status)
-		}
+		suite.Run();
 	}
 
 	//Incremental, Separate
@@ -163,9 +159,7 @@ func main() {
 		incremental = true
 		aggregated = false
 		godogOpts.Tags = "@incremental && @separate"
-		if status := suite.Run(); status == 1 {
-			os.Exit(status)
-		}
+		suite.Run();
 	}
 
 	//Incremental, Aggregated
@@ -173,9 +167,7 @@ func main() {
 		incremental = true
 		aggregated = true
 		godogOpts.Tags = "@incremental && @aggregated"
-		if status := suite.Run(); status == 1 {
-			os.Exit(status)
-		}
+		suite.Run();
 	}
 	os.Exit(0)
 }


### PR DESCRIPTION
This PR adds ADS support to our test runner through the use of a new command line flag, and implements an ADS-only test.  Below is the design diary for this work ([source](https://github.com/ii/xds-test-harness/blob/ads-work/diary/ads-support.org)), to help give context to the changes!

---
## ADS Support Design Diary
- [Introduction](#org36288f8)
  - [Background](#org39571a9)
  - [Design](#org6e1b070)
    - [Specifying variants with cli flags](#orgf9a4c56)
    - [Tagging  the tests](#org892c61a)
    - [reading flags and tags in our main](#org991b796)
    - [Changes to our test Steps](#orgd265b69)
    - [Uncertain changes](#org319ac2a)
  - [Questions](#org7a965bb)



<a id="org36288f8"></a>

# Introduction

This diary is a work-in-progress to document how we added ADS support to the xDS test harness. It sets up a background of the problem, our design of the work, and any lingering questions I have.


<a id="org39571a9"></a>

# Background

The xDS transport protocol has [four variants](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#variants-of-the-xds-transport-protocol):

-   State of the World, non-aggregated
-   SOTW, aggregated
-   Incremental(or delta), non-aggregated
-   Incremental, aggregated

Each of the variants are handled by [different RPC services/methods](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#rpc-services-and-methods-for-each-variant), and an xDS server can support any or all of them at the same time.

For example, for LDS, the various protocol variants are provided via the following RPC methods:

-   SotW, non aggregated: ListenerDiscoveryService.StreamListeners
-   SOTW, Aggregated : AggregatedDiscoveryService.StreamAggregatedResources
-   Incremental, non-agg: ListenerDiscoveryService.DeltaListeners
-   Incremental, Aggregated: AggregatedDiscoveryService.DeltaAggregatedResources

For SotW and incremental, the actual communication on the stream will be essentially the same for both aggregated and non-aggregated, regardless of which of the above RPC methods you use to create the stream.

For our tests, then, when a test is not variant specific, we should run the same test for each qualifying variant, by opening a stream with the correct RPC. For example, with a basic LDS test, our test runner should be able to run it against both `ListenerDiscoveryService.StreamListeners` and `AggregatedDisocveryService.StreamAggregatedResources`.

A target server may be configured for any subset of combinations from the four variants, and we should not lock in any required configuration for our tests. Instead, through something like command line flags, a person can tell the test runner which variants their implementation supports.


<a id="org6e1b070"></a>

# Design


<a id="orgf9a4c56"></a>

## Specifying variants with cli flags

A person should only start the runner once, and then the runner executes the test suite against the different set variants, by running the right stream against each of the supported, appropriate RPC methods (as outlined above).

A person can indicate which variants their target supports using the flag `--variants`. This flag expects a four character string made up of 1&rsquo;s and 0&rsquo;s. 1 represents support, 0 non-support. The variants are, right to left, sotw non-agg, sotw agg, incremental non-agg, incremental agg.

So if a person wanted to run the test suite against a server running only non-aggregated, but supporting sotw and incremental, they&rsquo;d run:

    ./runner --variants 1010

If they are an edge case that only supports SoTW, non-aggregated and incremental, aggregated, then they&rsquo;d run:

    ./runner --variants 1001


<a id="org892c61a"></a>

## Tagging  the tests

For the tests themselves, some may be general enough to work across all variants, and some may only be appropriate for a particular combination. We can indicate this using [tags added to the top of the test scenario](https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L8). The tags are:

-   @sotw
-   @incremental
-   @aggregate
-   @separate


<a id="org991b796"></a>

## reading flags and tags in our main

In our main function, we [parse the variant flag](https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L101) to build an array of boolean values. For each true value in the array, we [run the test suite](https://github.com/ii/xds-test-harness/blob/ads-work/main.go#L152) for that variant. This means the suite can run from 1-4 times.


<a id="orgd265b69"></a>

## Changes to our test Steps

The main flow for our tests is to set up state on the target server using the adapter, then [initialize a service](https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/services.go#L39) for the duration of the test. This service includes channels for requests and responses (and caches for both). Each test step in the scenario can use this service interface to pass along new requests or update state as nceeded.

We can use the same pattern for ADS, with some modifications:

Originally, the service interface included its typeURL value. When we needed to make a new request, we&rsquo;d use the service&rsquo;s assign typeURL. This doesn&rsquo;t work for ADs, so now [our new request functions pass the required typeURL](https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L102), which is determined from the test step itself.

Originally, our subscribing step assumed you would be doing one subscription per scenario, and so built a service interface as part of the subscription step. This doesn&rsquo;t work for ADS-Only tests where you are subscribing to multiple services across the same stream, and building a new service interface means clearing the existing caches. Now, the subscribing function [checks if we already](https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L107) have a service initialized and, if so, uses its existing inferface. I think this change makes the function stronger overall, and may help me fix the unsubscribing issues.


<a id="org319ac2a"></a>

## Uncertain changes

I added a new step at the end of our ADS-only test, that reads: [&ldquo;And the server never responds more than necessary&rdquo;](https://github.com/ii/xds-test-harness/blob/ads-work/features/subscriptions.feature#L192).

This step is functionally identical to our current step [&ldquo;And the client ACKS to which the server does not respond&rdquo;.](https://github.com/ii/xds-test-harness/blob/ads-work/internal/runner/steps.go#L257)

I duplicated the function due to an issue in the function&rsquo;s logic. It closes down our response and request channels, so that any remaining messages can come through and we can look at the entire range of messages sent. Then, we count the # of responses and # of requests. Since ACK&rsquo;ing is built into the client&rsquo;s lifecycle, and it is acking every response it gets from the server, than in this final step there should be 1 more request than response. If not, the step fails.

This logic requires the step to be run at the end of the test. However, in the test cases doc, for the ADS-only test there are multiple &ldquo;and the client sends an ack to which the server doesn&rsquo;t respond&rdquo;. If I tried to match the test case verbatim, we&rsquo;d be closing the ADS stream too early. If I just put the existing step at the end, it seems as if we are only ACK&rsquo;ing once.

Now, the ACK&rsquo;ing is assumed to happen as part of the test, and we just check at the end that the server hasn&rsquo;t sent more responses than it needed to. I worry this makes the test steps too opaque, and it may be highlighting that the existing steps are not as elegant as they could be. I am v. open for feedback or suggestions on if this needs to change, and how it could be improved.


<a id="org7a965bb"></a>

# Questions

-   Does the wording of the ADS test work for everyone?
    -   does the test run as we&rsquo;d expect?
-   Are there any objections/improvements to the &#x2013;variants flag?
