### PR TITLE
Config file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+targetAddress: 18000
+adapterAddress: 17000
+variants:
+  - sotw non-aggregated
+  - sotw aggregated
+  - incremental non-aggregated
+  - incremental aggregated

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,7 @@
+# xDS Conformance Configuration
+# All values are required.
+
+nodeID: test-id
 targetAddress: 18000
 adapterAddress: 17000
 variants:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cucumber/godog v0.12.1
 	github.com/envoyproxy/go-control-plane v0.10.1
 	github.com/golang/protobuf v1.5.0
+	github.com/kylelemons/go-gypsy v1.0.0
 	github.com/rs/zerolog v1.25.0
 	github.com/spf13/pflag v1.0.5
 	google.golang.org/grpc v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/go-gypsy v1.0.0 h1:7/wQ7A3UL1bnqRMnZ6T8cwCOArfZCxFmb1iTxaOOo1s=
+github.com/kylelemons/go-gypsy v1.0.0/go.mod h1:chkXM0zjdpXOiqkCW1XcCHDfjfk14PH2KKkQWxfJUcU=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -88,7 +89,11 @@ func (r *Runner) ConnectClient(server, address string) error {
 	if server == "adapter" {
 		client = r.Adapter
 	}
-	client.Port = address
+	if strings.HasPrefix(address, ":") {
+		client.Port = address
+	} else {
+		client.Port = ":" + address
+	}
 	conn, err := connectViaGRPC(client, server)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR enables someone to pass a config file to the runner to set up the testing environment.

You pass the config in with `runner --config "path/to/config.yaml"`

The config overrides any other command line args set, save the ones used for debugging(e.g. `--debug` and` --tags`).


