### PR TITLE
Improved logging

### DIFF
--- a/diary/improved-logging.org
+++ b/diary/improved-logging.org
@@ -1,0 +1,45 @@
+#+TITLE: Improved Logging
+
+* Logging to a file
+This is a built in feature of godog, where we can output the test results to a
+file. There are five types of built-in formatters for this output:
+- cucumber :: JSON. Includes the step, keyword, and result for each scenario and
+  feature. Follows a spec, so can be ingested by other tools easily.
+- pretty :: Meant to be printed to console. The default readout for godog, that
+  shows the test being run, the lines it's attached to, whether the lines are
+  passing, and the final results. Not structured to be ingested elsewhere.
+- event :: JSON. emits every event that happens during the test suite, like
+  finding a test step, running it, finishing the step, moving to the next one.
+  In each event, you have the name, timestamp, line from the gherkin document
+  that is being run. For the ...Finished steps, it also includes a
+  result...showing whether a test step has passed or if the entire test run has
+  passed.
+- progress :: Like a compact version of ~pretty~. Shows a dot for each test, the
+  dots increasing along the screen as the test suite progresses. Ends with a
+  summary of # of tests run, # of tests passed, and how long it took.
+- junit :: XML. Follows the junit script, ~<testsuite>~ tag with nested
+  ~<testcase>~ tags, each one with a status of passed or failed.
+You can output to any of them using the Format option of godog. To output to a
+file, you would do
+: Format: 'cucumber:path/to/file.json'
+to output multiple formats you do a comma-separated list. For example, to output
+to a junit xml file and also a pretty console print, you would do:
+: Format 'pretty,junit:path/to/file.xml'
+* What I want
+I want to still have pretty logging of some sort, so that when you run the suite
+youc an see, in near real-time, how it is doing. But I also want to have a
+combined results json at the end that details how many variants were tested
+against, the overall suite results, and the results per variant. We could also
+print out the cucumber.json for each test suite, so that someone can study the
+tests in detail or have them ingested into another program.
+* Custom Formatter
+Godog has the feature of building a custom formatter, so you can structure the test
+results however you see fit.  The junit, cucumber, pretty, etc. are all actually
+built-in custom formats. To add a new one, you register it with the formatter and have
+it inherit some basic, but adjust them as you see fit.
+* Progress
+** TODO register a custom format that looks like junit
+The junit results are the closest to the summary that I want, I think, without
+giving too much additional detail.
+** Can i adjust the results so the feature includes a meta tag for the variant?
+** Can I print out output along with printing to file?

--- a/features/subscribing.feature
+++ b/features/subscribing.feature
@@ -1,11 +1,11 @@
-Feature: Fetching Resources with LDS and CDS
+Feature: Subscribing to Resources
   Client can do wildcard subscriptions or normal subscriptions
   and receive updates when any subscribed resources change.
 
   These features come from this list of test cases:
   https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
 
-  @sotw @non-aggregated @aggregated @active
+  @sotw @non-aggregated @aggregated
   Scenario Outline: The service should send all resources on a wildcard request.
     Given a target setup with <service>, <resources>, and <starting version>
     When the Client does a wildcard subscription to <service>
@@ -121,77 +121,3 @@ Feature: Fetching Resources with LDS and CDS
       | service | starting version | resources   | subset of resources | existing subset | chosen resource | next version |
       | "RDS"   | "1"              | "A,B,C,D"   | "A,Z"               | "A"             | "Z"             | "2"          |
       | "EDS"   | "1"              | "A,B,C,D"   | "A,Z"               | "A"             | "Z"             | "2"          |
-
-
-  @CDS @LDS @sotw @non-aggregated @aggregated
-  Scenario: Client can unsubcribe from some resources
-    # This test does not check if the final results are only the subscribed resources
-    # it is valid(though not desired) for a server to send more than is requested.
-    # So the test will pass if client subscribes to A,B,C, unsubscribes from B,C and gets A,B,C back.
-    Given a target setup with <service>, <resources>, and <starting version>
-    When the Client subscribes to a <subset of resources> for <service>
-    Then the Client receives the <subset of resources> and <starting version>
-    When the Client updates subscription to a <resource from subset> of <service> with <starting version>
-    And a <resource from subset> of the <service> is updated to the <next version>
-    Then the Client receives the <resource from subset> and <next version>
-    And the Client sends an ACK to which the <service> does not respond
-
-    Examples:
-      | service | starting version | resources   | subset of resources | resource from subset |   next version  |
-      | "CDS"   | "1"              | "F,A,B,C,D" | "C,A,B"             | "A,C"                |   "2"           |
-      | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
-
-
-  @sotw @non-aggregated @aggregated
-  Scenario: Client can unsubcribe from some resources
-    # difference from test above is use of the word ONLY in the final THEN step
-    # This currently does not pass for go-control-plane
-    Given a target setup with <service>, <resources>, and <starting version>
-    When the Client subscribes to a <subset of resources> for <service>
-    Then the Client receives the <subset of resources> and <starting version>
-    When the Client updates subscription to a <resource from subset> of <service> with <starting version>
-    And a <resource from subset> of the <service> is updated to the <next version>
-    Then the Client receives only the <resource from subset> and <next version>
-    And the Client sends an ACK to which the <service> does not respond
-
-    Examples:
-      | service | starting version | resources   | subset of resources | resource from subset |   next version  |
-      | "RDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
-      | "EDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
-
-
-  @sotw @non-aggregated @aggregated
-  Scenario: Client can unsubscribe from all resources
-    # This is not working currently, the unsusbcribe is not registered,
-    # neither as an unsubscribe nor a new wildcard request
-    Given a target setup with <service>, <resources>, and <starting version>
-    When the Client subscribes to a <subset of resources> for <service>
-    Then the Client receives the <subset of resources> and <starting version>
-    When the Client unsubscribes from all resources for <service>
-    And a <subset of resources> of the <service> is updated to the <next version>
-    Then the Client does not receive any message from <service>
-
-    Examples:
-      | service | starting version | resources   | subset of resources | next version |
-      | "CDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
-      | "LDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
-      | "RDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
-      | "EDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
-
-
-    @sotw @aggregated
-    Scenario: Client can subscribe to multiple services via ADS
-      Given a target setup with <service>, <resources>, and <starting version>
-      When the Client subscribes to a <subset of resources> for <service>
-      Then the Client receives the <subset of resources> and <starting version> for <service>
-      When the Client subscribes to a <subset of resources> for <other service>
-      Then the Client receives the <subset of resources> and <starting version> for <other service>
-      When a <subset of resources> of the <service> is updated to the <next version>
-      Then the Client receives the <subset of resources> and <next version> for <service>
-      # trying out different language for server not responding to acks
-      And the service never responds more than necessary
-
-      Examples:
-        | service | other service | starting version | resources | subset of resources | next version |
-        | "CDS"   | "LDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |
-        | "RDS"   | "EDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |

--- a/features/unsubcribing.feature
+++ b/features/unsubcribing.feature
@@ -1,0 +1,80 @@
+Feature: Unsubscribing to Resources
+  After subscribing to a set of resources, a client can unbuscribe from any
+  or all of these resources. The client should no longer receive updates from
+  resources they've unsubcribed to.
+
+  These features come from this list of test cases:
+  https://docs.google.com/document/d/19oUEt9jSSgwNnvZjZgaFYBHZZsw52f2MwSo6LWKzg-E
+
+  @CDS @LDS @sotw @non-aggregated @aggregated
+  Scenario: Client can unsubcribe from some resources
+    # This test does not check if the final results are only the subscribed resources
+    # it is valid(though not desired) for a server to send more than is requested.
+    # So the test will pass if client subscribes to A,B,C, unsubscribes from B,C and gets A,B,C back.
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client subscribes to a <subset of resources> for <service>
+    Then the Client receives the <subset of resources> and <starting version>
+    When the Client updates subscription to a <resource from subset> of <service> with <starting version>
+    And a <resource from subset> of the <service> is updated to the <next version>
+    Then the Client receives the <resource from subset> and <next version>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      | service | starting version | resources   | subset of resources | resource from subset |   next version  |
+      | "CDS"   | "1"              | "F,A,B,C,D" | "C,A,B"             | "A,C"                |   "2"           |
+      | "LDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
+
+
+  @sotw @non-aggregated @aggregated
+  Scenario: Client can unsubcribe from some resources
+    # difference from test above is use of the word ONLY in the final THEN step
+    # This currently does not pass for go-control-plane
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client subscribes to a <subset of resources> for <service>
+    Then the Client receives the <subset of resources> and <starting version>
+    When the Client updates subscription to a <resource from subset> of <service> with <starting version>
+    And a <resource from subset> of the <service> is updated to the <next version>
+    Then the Client receives only the <resource from subset> and <next version>
+    And the Client sends an ACK to which the <service> does not respond
+
+    Examples:
+      | service | starting version | resources   | subset of resources | resource from subset |   next version  |
+      | "RDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
+      | "EDS"   | "1"              | "G,B,L,D"   | "B,D"               | "B"                  |   "2"           |
+
+
+  @sotw @non-aggregated @aggregated @skip
+  Scenario: Client can unsubscribe from all resources
+    # This is not working currently, the unsusbcribe is not registered,
+    # neither as an unsubscribe nor a new wildcard request
+    Given a target setup with <service>, <resources>, and <starting version>
+    When the Client subscribes to a <subset of resources> for <service>
+    Then the Client receives the <subset of resources> and <starting version>
+    When the Client unsubscribes from all resources for <service>
+    And a <subset of resources> of the <service> is updated to the <next version>
+    Then the Client does not receive any message from <service>
+
+    Examples:
+      | service | starting version | resources   | subset of resources | next version |
+      | "CDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
+      | "LDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
+      | "RDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
+      | "EDS"   | "1"              | "A,B,C,D"   | "A,B"               | "2"          |
+
+
+    @sotw @aggregated
+    Scenario: Client can subscribe to multiple services via ADS
+      Given a target setup with <service>, <resources>, and <starting version>
+      When the Client subscribes to a <subset of resources> for <service>
+      Then the Client receives the <subset of resources> and <starting version> for <service>
+      When the Client subscribes to a <subset of resources> for <other service>
+      Then the Client receives the <subset of resources> and <starting version> for <other service>
+      When a <subset of resources> of the <service> is updated to the <next version>
+      Then the Client receives the <subset of resources> and <next version> for <service>
+      # trying out different language for server not responding to acks
+      And the service never responds more than necessary
+
+      Examples:
+        | service | other service | starting version | resources | subset of resources | next version |
+        | "CDS"   | "LDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |
+        | "RDS"   | "EDS"         | "1"              | "A,B,C"   | "B"                 | "2"          |

--- a/fmt_xds.go
+++ b/fmt_xds.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	// "fmt"
+	"io"
+	// "math"
+
+	"github.com/cucumber/godog"
+	// "github.com/rs/zerolog/log"
+)
+
+func init() {
+	godog.Format("xds", "Formatter for the xDS Test Suite", xdsFormatterFunc)
+}
+
+func xdsFormatterFunc(suite string, out io.Writer) godog.Formatter {
+	return newXdsFmt(suite, out)
+}
+
+func newXdsFmt(suite string, out io.Writer) *xdsFmt {
+	return &xdsFmt{
+		CukeFmt: godog.NewCukeFmt(suite, out),
+		out:      out,
+	}
+}
+
+type xdsFmt struct {
+	*godog.CukeFmt
+	out io.Writer
+}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,13 @@ module github.com/ii/xds-test-harness
 go 1.16
 
 require (
-	github.com/cucumber/godog v0.12.1
+	github.com/cucumber/godog v0.12.4
+	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/envoyproxy/go-control-plane v0.10.1
+	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/golang/protobuf v1.5.0
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-memdb v1.3.2 // indirect
 	github.com/kylelemons/go-gypsy v1.0.0
 	github.com/rs/zerolog v1.25.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cucumber/gherkin-go/v19 v19.0.3 h1:mMSKu1077ffLbTJULUfM5HPokgeBcIGboyeNUof1MdE=
 github.com/cucumber/gherkin-go/v19 v19.0.3/go.mod h1:jY/NP6jUtRSArQQJ5h1FXOUgk5fZK24qtE7vKi776Vw=
-github.com/cucumber/godog v0.12.1 h1:IhWVYFKDReM5WsuA9AuRLRPWOyvFNO9UBUKrNfLPais=
-github.com/cucumber/godog v0.12.1/go.mod h1:u6SD7IXC49dLpPN35kal0oYEjsXZWee4pW6Tm9t5pIc=
+github.com/cucumber/godog v0.12.4 h1:m+vQaDztkpwpmkBIX6jlwNFJiuCMkPjz5jkrUq4SIlM=
+github.com/cucumber/godog v0.12.4/go.mod h1:u6SD7IXC49dLpPN35kal0oYEjsXZWee4pW6Tm9t5pIc=
 github.com/cucumber/messages-go/v16 v16.0.0/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
 github.com/cucumber/messages-go/v16 v16.0.1 h1:fvkpwsLgnIm0qugftrw2YwNlio+ABe2Iu94Ap8GMYIY=
 github.com/cucumber/messages-go/v16 v16.0.1/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
@@ -70,8 +70,9 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -121,10 +122,12 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-memdb v1.3.0 h1:xdXq34gBOMEloa9rlGStLxmfX/dyIK8htOv36dQUwHU=
+github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
+github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v1.3.0/go.mod h1:Mluclgwib3R93Hk5fxEfiRhB+6Dar64wWh71LpNSe3g=
+github.com/hashicorp/go-memdb v1.3.2 h1:RBKHOsnSszpU6vxq80LzC2BaQjuuvoyaQbkLTf7V7g8=
+github.com/hashicorp/go-memdb v1.3.2/go.mod h1:Mluclgwib3R93Hk5fxEfiRhB+6Dar64wWh71LpNSe3g=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=

--- a/internal/runner/suite.go
+++ b/internal/runner/suite.go
@@ -1,0 +1,248 @@
+// Test suite builders for each of the variants.
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+	pb "github.com/ii/xds-test-harness/api/adapter"
+	"github.com/ii/xds-test-harness/internal/types"
+	"github.com/rs/zerolog/log"
+)
+
+type Suite struct {
+	Variant     types.Variant
+	Runner      *Runner
+	Aggregated  bool
+	Incremental bool
+	Buffer      bytes.Buffer
+	Tags        string
+	TestSuite   godog.TestSuite
+}
+
+func (s *Suite) StartRunner(node, adapter, target string) error {
+	s.Runner = FreshRunner()
+	s.Runner.NodeID = node
+	s.Runner.Aggregated = s.Aggregated
+
+	if err := s.Runner.ConnectClient("target", target); err != nil {
+		log.Fatal().
+			Msgf("error connecting to target: %v", err)
+	}
+	if err := s.Runner.ConnectClient("adapter", adapter); err != nil {
+		log.Fatal().
+			Msgf("error connecting to adapter: %v", err)
+	}
+
+	log.Info().
+		Msgf("Connected to target at %s and adapter at %s\n", target, adapter)
+
+	if s.Runner.Aggregated {
+		log.Info().
+			Msgf("Tests will be run via a single aggregated streams")
+	} else {
+		log.Info().
+			Msgf("Tests will be run via separate, non-aggregated streams")
+	}
+	return nil
+}
+
+func (s *Suite) SetTags(base string) error {
+	tagList := []string{}
+	variants := strings.Split(string(s.Variant), " ")
+
+	if len(variants) < 1 {
+		err := fmt.Errorf("No variant type found to create tags from. This means the suite was not initialized properly.")
+		return err
+	}
+	for _, tag := range variants {
+		tag = "@" + tag
+		tagList = append(tagList, tag)
+	}
+	if base != "" {
+		tagList = append(tagList, base)
+	}
+	s.Tags = strings.Join(tagList, " && ")
+	return nil
+}
+
+func (b *Suite) ConfigureSuite() error {
+	initScenario := func(ctx *godog.ScenarioContext) {
+		ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
+			log.Debug().Msg("Creating Fresh Runner!")
+			b.Runner = FreshRunner(b.Runner)
+			return ctx, nil
+		})
+		ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
+			c := pb.NewAdapterClient(b.Runner.Adapter.Conn)
+			clearRequest := &pb.ClearRequest{Node: b.Runner.NodeID}
+			clear, err := c.ClearState(context.Background(), clearRequest)
+			if err != nil {
+				log.Err(err).
+					Msg("Couldn't clear state")
+			}
+			log.Debug().
+				Msgf("Clearing State: %v\n", clear.Response)
+			return ctx, nil
+		})
+		b.Runner.LoadSteps(ctx)
+	}
+
+	godogOpts := godog.Options{
+		ShowStepDefinitions: false,
+		Randomize:           0,
+		StopOnFailure:       false,
+		Strict:              false,
+		NoColors:            false,
+		Tags:                b.Tags,
+		Format:              "xds",
+		Output:              &b.Buffer,
+		Concurrency:         0,
+	}
+
+	suite := godog.TestSuite{
+		Name:                fmt.Sprintf("xds Test Suite [%v]", b.Variant),
+		ScenarioInitializer: initScenario,
+		Options:             &godogOpts,
+	}
+
+	b.TestSuite = suite
+	return nil
+}
+
+func (s *Suite) Run(adapter,target,nodeId,tags string) (err error, results types.VariantResults) {
+	if err = s.StartRunner(nodeId,adapter,target); err != nil {
+		return
+	}
+	if err = s.SetTags(tags); err != nil {
+		return
+	}
+	if err = s.ConfigureSuite(); err != nil {
+		return
+	}
+
+	s.TestSuite.Run()
+
+	cukeResults := []types.CukeFeatureJSON{}
+	if err = json.Unmarshal([]byte(s.Buffer.String()), &cukeResults); err != nil {
+		err = fmt.Errorf("Error unmarshalling test results: %v\n", err)
+		return err, results
+	}
+
+	for _, cuke := range cukeResults {
+		results = gatherResults(results, cuke)
+	}
+
+	results.Name = string(s.Variant)
+	return err, results
+}
+
+func NewSotwNonAggregatedSuite() *Suite {
+	return &Suite{
+		Variant:     types.SotwNonAggregated,
+		Aggregated:  false,
+		Incremental: false,
+		Buffer:      *bytes.NewBuffer(nil),
+	}
+}
+
+func NewSotwAggregatedSuite() *Suite {
+	return &Suite{
+		Variant:     types.SotwAggregated,
+		Aggregated:  true,
+		Incremental: false,
+		Buffer:      *bytes.NewBuffer(nil),
+	}
+
+}
+
+func NewIncrementalNonAggregatedSuite() *Suite {
+	return &Suite{
+		Variant:     types.IncrementalNonAggregated,
+		Aggregated:  false,
+		Incremental: true,
+		Buffer:      *bytes.NewBuffer(nil),
+	}
+
+}
+
+func NewIncrementalAggregatedSuite() *Suite {
+	return &Suite{
+		Variant:     types.IncrementalAggregated,
+		Aggregated:  true,
+		Incremental: true,
+		Buffer:      *bytes.NewBuffer(nil),
+	}
+}
+
+func NewSuite(variant types.Variant) *Suite {
+	switch variant {
+	case types.SotwNonAggregated:
+		return NewSotwNonAggregatedSuite()
+	case types.SotwAggregated:
+		return NewSotwAggregatedSuite()
+	case types.IncrementalNonAggregated:
+		return NewIncrementalNonAggregatedSuite()
+	case types.IncrementalAggregated:
+		return NewIncrementalAggregatedSuite()
+	default:
+		return nil
+	}
+}
+
+
+func UpdateResults(current types.Results, variantResults types.VariantResults) types.Results {
+	return types.Results{
+		Total:            current.Total  + variantResults.Total,
+		Passed:           current.Passed + variantResults.Passed,
+		Failed:           current.Failed + variantResults.Failed,
+		Variants:         append(current.Variants, variantResults.Name),
+		ResultsByVariant: append(current.ResultsByVariant, variantResults),
+	}
+}
+
+func gatherResults(current types.VariantResults, cuke types.CukeFeatureJSON) types.VariantResults {
+	totalTests := len(cuke.Elements)
+	passed := 0
+	failed := 0
+	failedTests := []types.FailedTest{}
+
+	for _, test := range cuke.Elements {
+		testPassed := true
+		for _, step := range test.Steps {
+			if step.Result.Status == "failed" {
+				testPassed = false
+				failedTests = append(failedTests, createFailedTest(test, step))
+			}
+		}
+		if testPassed {
+			passed++
+		} else {
+			failed++
+		}
+	}
+	current.Total += int64(totalTests)
+	current.Passed += int64(passed)
+	current.Failed += int64(failed)
+	current.FailedTests = append(current.FailedTests, failedTests...)
+	return current
+}
+
+func createFailedTest(scenario types.CukeElement, failedStep types.CukeStep) types.FailedTest {
+	return types.FailedTest{
+		Scenario:   scenario.Name,
+		FailedStep: failedStep.Name,
+		Source:     failedStep.Match.Location,
+	}
+}
+
+type SuiteConfig struct {
+	adapter string
+	target  string
+	nodeId  string
+	tags    string
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,96 @@
+package types
+
+type Variant string
+const (
+	SotwNonAggregated Variant = "sotw non-aggregated"
+	SotwAggregated Variant = "sotw aggregated"
+	IncrementalNonAggregated Variant = "incremental non-aggregated"
+	IncrementalAggregated Variant = "incremental aggregated"
+)
+
+type CukeComment struct {
+	Value string `json:"value"`
+	Line  int    `json:"line"`
+}
+
+type CukeDocstring struct {
+	Value       string `json:"value"`
+	ContentType string `json:"content_type"`
+	Line        int    `json:"line"`
+}
+
+type CukeTag struct {
+	Name string `json:"name"`
+	Line int    `json:"line"`
+}
+
+type CukeResult struct {
+	Status   string `json:"status"`
+	Error    string `json:"error_message,omitempty"`
+	Duration *int   `json:"duration,omitempty"`
+}
+
+type CukeMatch struct {
+	Location string `json:"location"`
+}
+
+type CukeStep struct {
+	Keyword   string              `json:"keyword"`
+	Name      string              `json:"name"`
+	Line      int                 `json:"line"`
+	Docstring *CukeDocstring      `json:"doc_string,omitempty"`
+	Match     CukeMatch           `json:"match"`
+	Result    CukeResult          `json:"result"`
+	DataTable []*CukeDataTableRow `json:"rows,omitempty"`
+}
+
+type CukeDataTableRow struct {
+	Cells []string `json:"cells"`
+}
+
+type CukeElement struct {
+	ID          string     `json:"id"`
+	Keyword     string     `json:"keyword"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Line        int        `json:"line"`
+	Type        string     `json:"type"`
+	Tags        []CukeTag  `json:"tags,omitempty"`
+	Steps       []CukeStep `json:"steps,omitempty"`
+}
+
+// CukeFeatureJSON ...
+type CukeFeatureJSON struct {
+	URI         string        `json:"uri"`
+	ID          string        `json:"id"`
+	Keyword     string        `json:"keyword"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Line        int           `json:"line"`
+	Comments    []CukeComment `json:"comments,omitempty"`
+	Tags        []CukeTag     `json:"tags,omitempty"`
+	Elements    []CukeElement `json:"elements,omitempty"`
+}
+
+type Results  struct {
+	Total int64
+	Passed int64
+	Failed int64
+	Variants []string
+	ResultsByVariant []VariantResults
+}
+
+type VariantResults struct {
+	Name string
+	Total int64
+	Passed int64
+	Failed int64
+	FailedTests []FailedTest
+}
+
+type FailedTest struct {
+	Scenario string
+	FailedStep string
+	Feature string
+	Source string
+}

--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ func init() {
 }
 
 func InitializeTestSuite(sc *godog.TestSuiteContext) {
-
 	sc.BeforeSuite(func() {
 		r = runner.FreshRunner()
 		r.NodeID = *nodeID
@@ -196,6 +195,7 @@ func main() {
 		aggregated = false
 		customTags := []string{"@sotw", "@non-aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
+		godogOpts.Format = "pretty,cucumber:results/sotw-non-aggregated.json"
 		suite.Run()
 	}
 
@@ -204,6 +204,7 @@ func main() {
 		aggregated = true
 		customTags := []string{"@sotw", "@aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
+		godogOpts.Format = "pretty,cucumber:results/sotw-aggregated.json"
 		suite.Run()
 	}
 
@@ -212,6 +213,7 @@ func main() {
 		aggregated = false
 		customTags := []string{"@incremental", "@non-aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
+		godogOpts.Format = "pretty,cucumber:results/incremental-non-aggregated.json"
 		suite.Run()
 	}
 
@@ -220,6 +222,7 @@ func main() {
 		aggregated = true
 		customTags := []string{"@incremental", "@aggregated"}
 		godogOpts.Tags = combineTags(godogTags, customTags)
+		godogOpts.Format = "pretty,cucumber:results/incremental-aggregated.json"
 		suite.Run()
 	}
 	os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
+	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/cucumber/godog"
-	"github.com/cucumber/godog/colors"
-	pb "github.com/ii/xds-test-harness/api/adapter"
+	"github.com/ii/xds-test-harness/internal/parser"
 	"github.com/ii/xds-test-harness/internal/runner"
-	"github.com/kylelemons/go-gypsy/yaml"
+	"github.com/ii/xds-test-harness/internal/types"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
@@ -24,24 +21,7 @@ var (
 	targetAddress  = pflag.StringP("target", "T", ":18000", "port of xds target to test")
 	nodeID         = pflag.StringP("nodeID", "N", "test-id", "node id of target")
 	variant        = pflag.StringArrayP("variant", "V", []string{"sotw non-aggregated", "sotw aggregated", "incremental non-aggregated", "incremental aggregated"}, "xDS protocol variant your server supports. Add a separate flag per each supported variant.\n Possibleariants are: sotw non-aggregated\n, sotw aggregated\n, incremental non-aggregated\n, incremental aggregated\n.")
-
-
-	r *runner.Runner
-	aggregated     = false
-	incremental    = false
-
-	godogOpts = godog.Options{
-		ShowStepDefinitions: false,
-		Randomize:           0,
-		StopOnFailure:       false,
-		Strict:              false,
-		NoColors:            false,
-		Tags:                "",
-		Format:              "",
-		Concurrency:         0,
-		Paths:               []string{},
-		Output:              colors.Colored(os.Stdout),
-	}
+	godogOpts      = godog.Options{}
 )
 
 func init() {
@@ -51,310 +31,41 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 }
 
-func InitializeTestSuite(sc *godog.TestSuiteContext) {
-	sc.BeforeSuite(func() {
-		r = runner.FreshRunner()
-		r.NodeID = *nodeID
-		r.Aggregated = aggregated
-		if err := r.ConnectClient("target", *targetAddress); err != nil {
-			log.Fatal().
-				Msgf("error connecting to target: %v", err)
-		}
-		if err := r.ConnectClient("adapter", *adapterAddress); err != nil {
-			log.Fatal().
-				Msgf("error connecting to adapter: %v", err)
-		}
-		log.Info().
-			Msgf("Connected to target at %s and adapter at %s\n", *targetAddress, *adapterAddress)
-
-		if r.Aggregated {
-			log.Info().
-				Msgf("Tests will be run via ADS")
-		} else {
-			log.Info().
-				Msgf("Tests will be run non-aggregated, via separate streams")
-		}
-	})
-}
-
-func InitializeScenario(ctx *godog.ScenarioContext) {
-	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
-		log.Debug().Msg("Fresh Runner!")
-		r = runner.FreshRunner(r)
-		return ctx, nil
-	})
-	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
-		c := pb.NewAdapterClient(r.Adapter.Conn)
-		clearRequest := &pb.ClearRequest{
-			Node: r.NodeID,
-		}
-		clear, err := c.ClearState(context.Background(), clearRequest)
-		if err != nil {
-			log.Err(err).
-				Msg("Couldn't clear state")
-		}
-		log.Debug().
-			Msgf("Clearing state...%v", clear.Response)
-		return ctx, nil
-	})
-	r.LoadSteps(ctx)
-}
-
-func parseSupportedVariants(variants []string) (err error, supported map[string]bool) {
-	supported = make(map[string]bool)
-	for _, variant := range variants {
-		variant = strings.ToLower(strings.TrimSpace(variant))
-		switch variant {
-		case "sotw non-aggregated":
-			supported["sotw non-aggregated"] = true
-		case "sotw aggregated":
-			supported["sotw aggregated"] = true
-		case "incremental non-aggregated":
-			supported["incremental non-aggregated"] = true
-		case "incremental aggregated":
-			supported["incremental aggregated"] = true
-		default:
-			log.Info().Msgf("Cannot recognize variant: %v\nWe support:\nsotw non-aggregated\nsotw aggregated\nincremental non-aggregated\nincremental aggregated\n", variant)
-		}
-	}
-	return nil, supported
-}
-
-func combineTags(godogTags string, customTags []string) (tags string) {
-	if godogTags != "" {
-		customTags = append(customTags, godogTags)
-	}
-	tags = strings.Join(customTags, " && ")
-	return tags
-}
-
-func valuesFromConfig(config string) (target string, adapter string, nodeID string, supportedVariants map[string]bool) {
-	c, err := yaml.ReadFile(config)
-	if err != nil {
-		log.Fatal().Msgf("Cannot read config: %v", config)
-	}
-	nodeID, err = c.Get("nodeID")
-	if err != nil {
-		log.Fatal().Msgf("Error reading config file for Node ID: %v\n", err)
-	}
-	target, err = c.Get("targetAddress")
-	if err != nil {
-		log.Fatal().Msgf("Error reading config file for Target Address: %v\n", config, err)
-	}
-	adapter, err = c.Get("adapterAddress")
-	if err != nil {
-		log.Info().Msgf("Cannot get adapter address from config file: %v\n", err)
-	}
-	v, err := yaml.Child(c.Root, "variants")
-	if err != nil {
-		log.Fatal().Msgf("Error getting variants from config: %v\n", err)
-	}
-	variants := []string{}
-	varsInYaml, ok := v.(yaml.List)
-	if ok {
-		for i := 0; i < varsInYaml.Len(); i++ {
-			node := varsInYaml.Item(i)
-			variant := string(node.(yaml.Scalar))
-			variants = append(variants, variant)
-		}
-	}
-	err, supportedVariants = parseSupportedVariants(variants)
-	if err != nil {
-		log.Fatal().Msgf("Cannot parse supported variants from config: %v", err)
-	}
-	return target, adapter, nodeID, supportedVariants
-}
-
 func main() {
 	pflag.Parse()
-	godogOpts.Paths = pflag.Args()
 	godogTags := godogOpts.Tags
-	supportedVariants := make(map[string]bool)
 
 	if *debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
 	// default to using CLI Flag for settings
-	err, supportedVariants := parseSupportedVariants(*variant)
+	err, supportedVariants := parser.ParseSupportedVariants(*variant)
 	if err != nil {
 		log.Fatal().Msgf("Cannot parse variants from CLI: %v\n", err)
 	}
-
 	// If config present, use it for all non-debugging values
-	if *config != ""{
-		*targetAddress, *adapterAddress, *nodeID, supportedVariants = valuesFromConfig(*config)
+	if *config != "" {
+		*targetAddress, *adapterAddress, *nodeID, supportedVariants = parser.ValuesFromConfig(*config)
 	}
 
-	buf := bytes.NewBuffer(nil)
+	var results types.Results
+	for _, variant := range supportedVariants {
+		log.Info().
+			Msgf("Starting Tests for %v\n", string(variant))
 
-	suite := godog.TestSuite{
-		Name:                 "xDS Test Suite",
-		ScenarioInitializer:  InitializeScenario,
-		TestSuiteInitializer: InitializeTestSuite,
-		Options:              &godogOpts,
+		suite := runner.NewSuite(variant)
+		err, variantResults := suite.Run(*adapterAddress, *targetAddress, *nodeID, godogTags)
+		if err != nil {
+			log.Fatal().
+				Msgf("Error when attempting to run test suite: %v\n", err)
+		}
+		results = runner.UpdateResults(results, variantResults)
 	}
+	log.Info().
+		Msgf("All done, here are your results!!: %v\n", results)
 
-	if supportedVariants["sotw non-aggregated"] {
-		incremental = false
-		aggregated = false
-		customTags := []string{"@sotw", "@non-aggregated"}
-		godogOpts.Tags = combineTags(godogTags, customTags)
-		godogOpts.Format = "xds"
-		godogOpts.Output = buf
-		suite.Run()
-	}
-
-	var cukeResults []CukeFeatureJSON
-	var results Results
-
-	err = json.Unmarshal([]byte(buf.String()), &cukeResults)
-	if err != nil {
-		log.Err(err).Msgf("Error!!!: %v\n", err)
-	}
-
-	for _, cuke := range cukeResults {
-	  results = gatherResults(results, cuke)
-	}
-	log.Info().Msgf("Results! %v\n", results)
-
-	if supportedVariants["sotw aggregated"] {
-		incremental = false
-		aggregated = true
-		customTags := []string{"@sotw", "@aggregated"}
-		godogOpts.Tags = combineTags(godogTags, customTags)
-		// godogOpts.Format = "pretty,cucumber:results/sotw-aggregated.json"
-		suite.Run()
-	}
-
-	if supportedVariants["incremental non-aggregated"] {
-		incremental = true
-		aggregated = false
-		customTags := []string{"@incremental", "@non-aggregated"}
-		godogOpts.Tags = combineTags(godogTags, customTags)
-		godogOpts.Format = "pretty,cucumber:results/incremental-non-aggregated.json"
-		suite.Run()
-	}
-
-	if supportedVariants["incremental aggregated"] {
-		incremental = true
-		aggregated = true
-		customTags := []string{"@incremental", "@aggregated"}
-		godogOpts.Tags = combineTags(godogTags, customTags)
-		godogOpts.Format = "pretty,cucumber:results/incremental-aggregated.json"
-		suite.Run()
-	}
+	file, _ := json.MarshalIndent(results, "", "  ")
+	_ = ioutil.WriteFile("results.json", file, 0644)
 	os.Exit(0)
-}
-
-func gatherResults (current Results, cuke CukeFeatureJSON) Results {
-	totalTests := len(cuke.Elements)
-	passedTests := 0
-	failedTests := 0
-	failedScenarios := []string{}
-
-	for _, scenario := range cuke.Elements {
-		passed := true
-		for _, step := range scenario.Steps {
-			if step.Result.Status == "failed" {
-				passed = false
-			}
-		}
-		if passed {
-			passedTests++
-		} else {
-			failedTests++
-			failedScenarios = append(failedScenarios, scenario.Name)
-		}
-	}
-	current.Total += int64(totalTests)
-	current.Passed += int64(passedTests)
-	current.Failed += int64(failedTests)
-	return current
-}
-
-type cukeComment struct {
-	Value string `json:"value"`
-	Line  int    `json:"line"`
-}
-
-type cukeDocstring struct {
-	Value       string `json:"value"`
-	ContentType string `json:"content_type"`
-	Line        int    `json:"line"`
-}
-
-type cukeTag struct {
-	Name string `json:"name"`
-	Line int    `json:"line"`
-}
-
-type cukeResult struct {
-	Status   string `json:"status"`
-	Error    string `json:"error_message,omitempty"`
-	Duration *int   `json:"duration,omitempty"`
-}
-
-type cukeMatch struct {
-	Location string `json:"location"`
-}
-
-type cukeStep struct {
-	Keyword   string              `json:"keyword"`
-	Name      string              `json:"name"`
-	Line      int                 `json:"line"`
-	Docstring *cukeDocstring      `json:"doc_string,omitempty"`
-	Match     cukeMatch           `json:"match"`
-	Result    cukeResult          `json:"result"`
-	DataTable []*cukeDataTableRow `json:"rows,omitempty"`
-}
-
-type cukeDataTableRow struct {
-	Cells []string `json:"cells"`
-}
-
-type cukeElement struct {
-	ID          string     `json:"id"`
-	Keyword     string     `json:"keyword"`
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	Line        int        `json:"line"`
-	Type        string     `json:"type"`
-	Tags        []cukeTag  `json:"tags,omitempty"`
-	Steps       []cukeStep `json:"steps,omitempty"`
-}
-
-// CukeFeatureJSON ...
-type CukeFeatureJSON struct {
-	URI         string        `json:"uri"`
-	ID          string        `json:"id"`
-	Keyword     string        `json:"keyword"`
-	Name        string        `json:"name"`
-	Description string        `json:"description"`
-	Line        int           `json:"line"`
-	Comments    []cukeComment `json:"comments,omitempty"`
-	Tags        []cukeTag     `json:"tags,omitempty"`
-	Elements    []cukeElement `json:"elements,omitempty"`
-}
-
-type Results  struct {
-	Total int64
-	Passed int64
-	Failed int64
-	Variants []string
-	ResultsByVariant []VariantResults
-}
-
-type VariantResults struct {
-	Name string
-	Total int64
-	Passed int64
-	Failed int64
-	FailedTests []FailedTest
-}
-
-type FailedTest struct {
-	Scenario string
-	FailedStep string
-	Source string
 }


### PR DESCRIPTION
This PR is a major change to the output of the test runner. It's intent is to better handle a person wanting to run the test suite against their server, which is set up for to handle multiple variants.  I assume This person will want to have combined results for how their server did overall, and for the results to be broken apart by variant.

To manage this, I set up a custom formatter for the godog library, and feed our test results to this formatter, which collects the multiple test suites into a single json file.  I also refactored how these test suites were run, moving them into their own struct. This makes the main page easier to read, and the test suite easier to maintain as we add complexity.

There will be more work needed to get nicer console output at the end, and to improve the language of the tests so they read more clearly in the final json.  This is a working proof of concept.