### PR TITLE
Fix adapter bug

### DIFF
--- a/features/delta.feature
+++ b/features/delta.feature
@@ -105,6 +105,8 @@ Feature: Delta
       And the Client receives the resources <r1> and version <v1> for <xDS2>
      When the resource <r1> of service <xDS> is updated to version <v2>
      Then the Client receives the resources <r1> and version <v2> for <xDS>
+     When the resource <r1> of service <xDS2> is updated to version <v2>
+     Then the Client receives the resources <r1> and version <v2> for <xDS2>
       And the service never responds more than necessary
 
     Examples:

--- a/internal/runner/steps.go
+++ b/internal/runner/steps.go
@@ -280,7 +280,7 @@ func (r *Runner) ClientReceivesResourcesAndVersionForService(resources, version,
 			return fmt.Errorf("could not find expected response within grace period of 10 seconds. %v", err)
 		case <-done:
 			actualResources := r.Validate.Resources[typeUrl]
-			log.Debug().Msgf("Actual resources: %v", actualResources)
+			log.Debug().Msgf("Current resources: %v", r.Validate.Resources)
 			for _, resource := range expectedResources {
 				actual, ok := actualResources[resource]
 				if !ok {
@@ -426,13 +426,12 @@ func (r *Runner) ResourceOfServiceIsUpdatedToVersion(resource, service, version 
 		ResourceName: resource,
 		Version:      version,
 	}
-
+	log.Debug().
+		Msgf("Updating %v resource %v to version %v", service, resource, version)
 	_, err = c.UpdateResource(context.Background(), in)
 	if err != nil {
 		return fmt.Errorf("cannot update resource using adapter: %v", err)
 	}
-	log.Debug().
-		Msgf("Updating resource %v to version %v", resource, version)
 	return nil
 }
 


### PR DESCRIPTION
this fixes a bug noticed by @zp9763 , that came after updating our adapter to the latest version of go-control-plane.  There was a slight change to the getResources function for the go-control-plane's cache that we use, that required us
to build up a new snapshot from the results of calling `cache.GetSnapshot()` instead of using `cache.GetSnapshot()` directly.  When I first updated the code, I inadvertently dropped resources from any type other than the one we are currently testing.  For most tests this would be okay, but causes issues when testing ADS.

I upgraded the example adapter's updateResource function to create a new snapshot that includes all the resources, across types, from the current state, and then also upgrades the given resource, and uses this complete snapshot to set the new state.  